### PR TITLE
Build a project asynchronously

### DIFF
--- a/test/VSSDK.TestExtension/Commands/BuildActiveProjectAsyncCommand.cs
+++ b/test/VSSDK.TestExtension/Commands/BuildActiveProjectAsyncCommand.cs
@@ -1,0 +1,26 @@
+﻿using Community.VisualStudio.Toolkit;
+using EnvDTE;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+namespace TestExtension.Commands
+{
+    [Command(PackageIds.BuildActiveProjectAsync)]
+    internal sealed class BuildActiveProjectAsyncCommand : BaseCommand<BuildActiveProjectAsyncCommand>
+    {
+        protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            var activeProject = await VS.Solution.GetActiveProjectAsync();
+            if (activeProject != null)
+            {
+                var buildResult = await activeProject.BuildAsync();
+                if (buildResult)
+                    VS.Notifications.ShowMessage("Build Result", $"The '{activeProject.Name}' project was built successfully!");
+                else
+                    VS.Notifications.ShowError("Build Result", $"The '{activeProject.Name}' project did not build successfully :(");
+            }
+        }
+    }
+}

--- a/test/VSSDK.TestExtension/TestExtensionPackage.cs
+++ b/test/VSSDK.TestExtension/TestExtensionPackage.cs
@@ -5,6 +5,7 @@ using Community.VisualStudio.Toolkit;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using TestExtension;
+using TestExtension.Commands;
 using Task = System.Threading.Tasks.Task;
 
 namespace VSSDK.TestExtension
@@ -33,6 +34,7 @@ namespace VSSDK.TestExtension
             await RunnerWindowCommand.InitializeAsync(this);
             await ThemeWindowCommand.InitializeAsync(this);
             await MultiInstanceWindowCommand.InitializeAsync(this);
+            await BuildActiveProjectAsyncCommand.InitializeAsync(this);
         }
     }
 }

--- a/test/VSSDK.TestExtension/VSCommandTable.cs
+++ b/test/VSSDK.TestExtension/VSCommandTable.cs
@@ -20,8 +20,11 @@ namespace TestExtension
     /// </summary>
     internal sealed partial class PackageIds
     {
+        public const int TestExtensionMainMenu = 0x1000;
+        public const int TestExtensionMainMenuGroup1 = 0x1100;
         public const int RunnerWindow = 0x0100;
         public const int ThemeWindow = 0x0101;
         public const int MultiInstanceWindow = 0x0102;
+        public const int BuildActiveProjectAsync = 0x0103;
     }
 }

--- a/test/VSSDK.TestExtension/VSCommandTable.vsct
+++ b/test/VSSDK.TestExtension/VSCommandTable.vsct
@@ -5,10 +5,27 @@
   <Extern href="vsshlids.h"/>
   <Include href="KnownImageIds.vsct"/>
   <Include href="VSGlobals.vsct"/>
-
+  
   <Commands package="TestExtension">
     <!--This section defines the elements the user can interact with, like a menu command or a button
         or combo box in a toolbar. -->
+
+    <Menus>
+      <Menu guid="TestExtension" id="TestExtensionMainMenu" type="Menu">
+        <Parent guid="guidSHLMainMenu" id="IDG_VS_MM_MACROS" />
+        <Strings>
+          <ButtonText>VSSDK Test Extension</ButtonText>
+        </Strings>
+      </Menu>
+    </Menus>
+    
+    <Groups>
+      <Group guid="TestExtension" id="TestExtensionMainMenuGroup1" priority="0x1100">
+        <!--<Parent guid="guidSHLMainMenu" id="IDM_VS_MENU_TOOLS"/>-->
+        <Parent guid="TestExtension" id="TestExtensionMainMenu" />
+      </Group>
+    </Groups>
+    
     <Buttons>
       <Button guid="TestExtension" id="RunnerWindow" priority="0x0105" type="Button">
         <Parent guid="VSMainMenu" id="View.DevWindowsGroup.OtherWindows.Group1"/>
@@ -36,14 +53,27 @@
           <ButtonText>Multi-&amp;Instance Window</ButtonText>
         </Strings>
       </Button>
+
+      <Button guid="TestExtension" id="BuildActiveProjectAsync" priority="0x0108" type="Button">
+        <Parent guid="TestExtension" id="TestExtensionMainMenuGroup1"/>
+        <Icon guid="ImageCatalogGuid" id="BuildSelection" />
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <Strings>
+          <ButtonText>Build Active Project Async</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
   </Commands>
 
   <Symbols>
     <GuidSymbol name="TestExtension" value="{05271709-8845-42fb-9d10-621cc8cffc5d}">
+      <IDSymbol name="TestExtensionMainMenu" value="0x1000" />
+      <IDSymbol name="TestExtensionMainMenuGroup1" value="0x1100" />
+      
       <IDSymbol name="RunnerWindow" value="0x0100" />
       <IDSymbol name="ThemeWindow" value="0x0101" />
-      <IDSymbol name="MultiInstanceWindow" value="0x0102" />      
+      <IDSymbol name="MultiInstanceWindow" value="0x0102" />
+      <IDSymbol name="BuildActiveProjectAsync" value="0x0103" />
     </GuidSymbol>
   </Symbols>
 </CommandTable>

--- a/test/VSSDK.TestExtension/VSSDK.TestExtension.csproj
+++ b/test/VSSDK.TestExtension/VSSDK.TestExtension.csproj
@@ -45,6 +45,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Commands\BuildActiveProjectAsyncCommand.cs" />
     <Compile Include="Commands\MultiInstanceWindowCommand.cs" />
     <Compile Include="Commands\RunnerWindowCommand.cs" />
     <Compile Include="Commands\ThemeWindowCommand.cs" />


### PR DESCRIPTION
This PR adds a new extension method that allows building a project asynchronously and returns the build result as a `bool`.  To test this I have also added a new main menu and group that can be used for testing this and a good place for future commands for testing: 

![image](https://user-images.githubusercontent.com/11198735/115272377-91e6f580-a0fb-11eb-9fb8-e9d699634c88.png)

If this is deemed useful I can also look at doing something similar for the solution.



