### PR TITLE
Verify that the package has a ProvideToolWindow attribute

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/ToolWindows/BaseToolWindow.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ToolWindows/BaseToolWindow.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -53,6 +55,16 @@ namespace Community.VisualStudio.Toolkit
 
             _package = package;
             _implementation = new T() { Package = package };
+
+            // Verify that the package has a ProvideToolWindow attribute for this tool window.
+            var toolWindowAttributes = (ProvideToolWindowAttribute[])package.GetType().GetCustomAttributes(typeof(ProvideToolWindowAttribute), true);
+            ProvideToolWindowAttribute? foundToolWindowAttr = toolWindowAttributes.FirstOrDefault(a => a.ToolType == _implementation.PaneType);
+            if (foundToolWindowAttr == null)
+            {
+                Debug.Fail($"The tool window '{typeof(T).Name}' requires a ProvideToolWindow attribute on the package.");  // For testing debug build of the toolkit (not for users of the release-built nuget package).
+                throw new InvalidOperationException($"The tool window '{typeof(T).Name}' requires a ProvideToolWindow attribute on the package.");
+            }
+
             package.AddToolWindow(_implementation);
         }
 


### PR DESCRIPTION
While playing around with an extension and the toolkit I noticed that my command didn't open my tool window, and I soon found it was because I forgot the `ProvideToolWindow` attribute on the package. But new extenders may not realize this so quickly so I thought it would be useful to provide some feedback rather than silently failing.

This pull request modifies `BaseToolWindow<T>.Initialize` so that it throws if the package doesn't have a corresponding `ProvideToolWindow` attribute set for the tool window's Pane.

I also added a Debug.Fail but that will only fire for developers testing the toolkit itself -- not for users of the release-built nuget package.