### PR TITLE
Added extension methods around projects and hierarchies.

### DIFF
--- a/src/Community.VisualStudio.Toolkit.14.0/Community.VisualStudio.Toolkit.14.0.csproj
+++ b/src/Community.VisualStudio.Toolkit.14.0/Community.VisualStudio.Toolkit.14.0.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Madskristensen.VisualStudio.SDK" Version="14.0.83" IncludeAssets="All" PrivateAssets="None" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime" Version="12.1.30329" />
   </ItemGroup>
 
 </Project>

--- a/src/Community.VisualStudio.Toolkit.16.0/Community.VisualStudio.Toolkit.16.0.csproj
+++ b/src/Community.VisualStudio.Toolkit.16.0/Community.VisualStudio.Toolkit.16.0.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.*" IncludeAssets="All" PrivateAssets="None" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime" Version="16.7.30328.74" />
   </ItemGroup>
 
 </Project>

--- a/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/IVsHierarchyExtensions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/IVsHierarchyExtensions.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using EnvDTE;
+using Microsoft.Internal.VisualStudio.PlatformUI;
+
+namespace Microsoft.VisualStudio.Shell.Interop
+{
+    /// <summary>
+    /// Extension methods for the <see cref="IVsHierarchyExtensions"/> interface.
+    /// </summary>
+    public static class IVsHierarchyExtensions
+    {
+        /// <summary>
+        /// Converts an IVsHierarchy to a Project.
+        /// </summary>
+        public static Project? ToProject(this IVsHierarchy hierarchy)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (hierarchy == null)
+                throw new ArgumentNullException(nameof(hierarchy));
+
+            hierarchy.GetProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_ExtObject, out var obj);
+
+            return obj as Project;
+        }
+
+        /// <summary>
+        /// Returns whether the specified <see cref="IVsHierarchy"/> is an 'SDK' style project.
+        /// </summary>
+        /// <param name="vsHierarchy"></param>
+        /// <returns></returns>
+        public static bool IsSdkStyleProject(this IVsHierarchy vsHierarchy)
+        {
+            if (vsHierarchy == null)
+                throw new ArgumentNullException(nameof(vsHierarchy));
+
+            return vsHierarchy.IsCapabilityMatch("CPS");
+        }
+
+        /// <summary>
+        /// Returns the <see cref="IVsSharedAssetsProject"/> for the <see cref="IVsHierarchy"/>.
+        /// </summary>
+        /// <param name="vsHierarchy"></param>
+        /// <returns></returns>
+        public static IVsSharedAssetsProject? GetSharedAssetsProject(this IVsHierarchy vsHierarchy)
+        {
+            if (vsHierarchy == null)
+                throw new ArgumentNullException(nameof(vsHierarchy));
+
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            HierarchyUtilities.TryGetHierarchyProperty<IVsSharedAssetsProject>(
+                vsHierarchy,
+                (uint)VSConstants.VSITEMID.Root,
+                (int)__VSHPROPID7.VSHPROPID_SharedAssetsProject,
+                out var sharedAssetsProject);
+
+            return sharedAssetsProject;
+        }
+
+        /// <summary>
+        /// Returns whether the <see cref="IVsHierarchy"/> is a shared project.
+        /// </summary>
+        /// <param name="vsHierarchy"></param>
+        /// <returns></returns>
+        public static bool IsSharedProject(this IVsHierarchy vsHierarchy)
+        {
+            if (vsHierarchy == null)
+                throw new ArgumentNullException(nameof(vsHierarchy));
+
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            return vsHierarchy.GetSharedAssetsProject() != null;
+        }
+    }
+}

--- a/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/IVsShareAssetsProjectExtensions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/IVsShareAssetsProjectExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.Shell.Interop
+{
+    /// <summary>
+    /// Extension methods for the <see cref="IVsSharedAssetsProjectExtensions"/> interface.
+    /// </summary>
+    public static class IVsSharedAssetsProjectExtensions
+    {
+        /// <summary>
+        /// Returns a collection of hierarchies that refernce the shared project
+        /// </summary>
+        /// <param name="sharedAssetsProject"></param>
+        /// <returns></returns>
+        public static IEnumerable<IVsHierarchy> GetReferencingHierarchies(this IVsSharedAssetsProject sharedAssetsProject)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            foreach (IVsHierarchy importingProject in sharedAssetsProject.EnumImportingProjects())
+            {
+                yield return importingProject;
+            }
+        }
+    }
+}

--- a/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/IVsSolutionExtensions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/IVsSolutionExtensions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
 
             foreach (IVsHierarchy hier in GetAllProjectHierarchys(solution, flags))
             {
-                Project? project = ToProject(hier);
+                Project? project = hier.ToProject();
 
                 if (project != null)
                 {
@@ -73,23 +73,6 @@ namespace Microsoft.VisualStudio.Shell.Interop
                     yield return hierarchy[0];
                 }
             }
-        }
-
-        /// <summary>
-        /// Converts an IVsHierarchy to a Project.
-        /// </summary>
-        public static Project? ToProject(this IVsHierarchy hierarchy)
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            if (hierarchy == null)
-            {
-                throw new ArgumentNullException(nameof(hierarchy));
-            }
-
-            hierarchy.GetProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_ExtObject, out var obj);
-
-            return obj as Project;
         }
 
         /// <summary>

--- a/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/ProjectExtensions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/ProjectExtensions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Community.VisualStudio.Toolkit;
 using EnvDTE80;
+using Microsoft.Internal.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -177,6 +178,54 @@ namespace EnvDTE
                 // Returns 'true' if the number of failed projects == 0
                 buildTaskCompletionSource.TrySetResult(dte.Solution.SolutionBuild.LastBuildInfo == 0);
             }
+        }
+
+        /// <summary>
+        /// Returns the <see cref="IVsHierarchy"/> for the project.
+        /// </summary>
+        /// <param name="project"></param>
+        /// <returns></returns>
+        public static async Task<IVsHierarchy?> ToHierarchyAsync(this Project project)
+        {
+            if (project == null)
+                throw new ArgumentNullException(nameof(project));
+
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            var vsSolution = await VS.Solution.GetSolutionAsync();
+            if (vsSolution.GetProjectOfUniqueName(project.UniqueName, out var hierarchy) == VSConstants.S_OK)
+                return hierarchy;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns the unique project id as identified in the solution.
+        /// </summary>
+        /// <param name="project"></param>
+        /// <returns></returns>
+        public static async Task<Guid?> GetProjectIdAsync(this Project project)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            var hierarchy = await project.ToHierarchyAsync();
+            if (hierarchy != null && hierarchy.GetGuidProperty((uint)VSConstants.VSITEMID.Root, (int)__VSHPROPID.VSHPROPID_ProjectIDGuid, out var projectId) == 0)
+                return projectId;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns whether the project is an 'SDK' style project.
+        /// </summary>
+        /// <param name="project"></param>
+        /// <returns></returns>
+        public static async Task<bool> IsSdkStyleProjectAsync(this Project project)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            var hierarchy = await project.ToHierarchyAsync();
+            return hierarchy?.IsSdkStyleProject() ?? false;
         }
     }
 }

--- a/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/ProjectExtensions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/ProjectExtensions.cs
@@ -204,7 +204,7 @@ namespace EnvDTE
         /// </summary>
         /// <param name="project"></param>
         /// <returns></returns>
-        public static async Task<Guid?> GetProjectIdAsync(this Project project)
+        public static async Task<Guid?> GetProjectGuidAsync(this Project project)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 

--- a/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/ProjectExtensions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/ProjectExtensions.cs
@@ -227,5 +227,18 @@ namespace EnvDTE
             var hierarchy = await project.ToHierarchyAsync();
             return hierarchy?.IsSdkStyleProject() ?? false;
         }
+
+        /// <summary>
+        /// Returns whether the project is a 'Shared' project.
+        /// </summary>
+        /// <param name="project"></param>
+        /// <returns></returns>
+        public static async Task<bool> IsSharedProjectAsync(this Project project)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            var hierarchy = await project.ToHierarchyAsync();
+            return hierarchy?.IsSharedAssetsProject() ?? false;
+        }
     }
 }

--- a/src/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
+++ b/src/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
@@ -12,6 +12,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Commands\CommandAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\ExceptionExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\ImageMonikerExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\IVsHierarchyExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\IVsShareAssetsProjectExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\IVsSolutionExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\ProjectExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\ProjectItemExtensions.cs" />


### PR DESCRIPTION
These are some methods I've found useful and wanted to see if it made sense to add them here as well.  This PR adds the following extension methods:
* `IVsHierarchy.IsSdkStyleProject` - returns whether the hierarchy is a newer SDK style project or not
* `IVsHierarchy.IsSharedProject` - returns whether the hierarchy is a shared project or not
* `IVsHierarchy.GetSharedAssetsProject` - returns the `IVsSharedAssetsProject` object for the shared project
* `IVsSharedAssetsProject.GetReferencingHierarchies` - returns a collection of projects that reference the shared project
* `Project.ToHierarchyAsync` - returns the `IVsHierarchy` for the project
* `Project.GetProjectIdAsync` - returns the guid for the project as identified in the solution
* `Project.IsSdkStyleProjectAsync` - returns whether the project is a newer SDK style project or not
* `Project.IsSharedProjectAsync` - returns whether the project is a shared project or not