### PR TITLE
Created build target to check for presence of the Extensibility Essentials extension

### DIFF
--- a/Community.VisualStudio.Toolkit.sln
+++ b/Community.VisualStudio.Toolkit.sln
@@ -15,6 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		src\AssemblyInfo.cs = src\AssemblyInfo.cs
 		src\Common.props = src\Common.props
 		src\Community.VisualStudio.Toolkit.props = src\Community.VisualStudio.Toolkit.props
+		src\Community.VisualStudio.Toolkit.targets = src\Community.VisualStudio.Toolkit.targets
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/src/Common.props
+++ b/src/Common.props
@@ -35,6 +35,7 @@
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)Icon.png" Link="Icon.png" Pack="true" PackagePath="" Visible="false" />
     <None Include="../Community.VisualStudio.Toolkit.props" Pack="true" PackagePath="build" Visible="false" />
+    <None Include="../Community.VisualStudio.Toolkit.targets" Pack="true" PackagePath="build" Visible="false" />
     <None Include="../AssemblyInfo.cs" Pack="true" PackagePath="build" Visible="false" />
   </ItemGroup>
 

--- a/src/Community.VisualStudio.Toolkit.targets
+++ b/src/Community.VisualStudio.Toolkit.targets
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <Target Name="ExtensibilityEssentialsCheck" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <!-- 
+      Determine whether a `HelpLink` property is supported on Warning and Error tasks. 
+      The ability to supply a `HelpLink` property was added in MSBuild v16.8.
+      -->
+      <MSBuildMajorVersion>$([System.Version]::Parse($(MSBuildVersion)).Major)</MSBuildMajorVersion>
+      <MSBuildMinorVersion>$([System.Version]::Parse($(MSBuildVersion)).Minor)</MSBuildMinorVersion>
+      <WarningsAndErrorsHaveHelpLink Condition="($(MSBuildMajorVersion) > 16) or ($(MSBuildMajorVersion) == 16 and $(MSBuildMinorVersion) >= 8)">true</WarningsAndErrorsHaveHelpLink>
+    </PropertyGroup>
+      
+    <PropertyGroup>
+      <!-- Message text. -->
+      <ExtensibilityEssentialsInfoText Condition="'$(ExtensibilityEssentialsInfoText)' == ''">The 'Extensibility Essentials' extension makes extension development easier.</ExtensibilityEssentialsInfoText>
+      <ExtensibilityEssentialsWarningText Condition="'$(ExtensibilityEssentialsWarningText)' == ''">The 'Extensibility Essentials' extension is recommended for this project.</ExtensibilityEssentialsWarningText>
+      <ExtensibilityEssentialsErrorText Condition="'$(ExtensibilityEssentialsErrorText)' == ''">The 'Extensibility Essentials' extension is required for this project.</ExtensibilityEssentialsErrorText>
+
+      <!-- Message metadata. -->
+      <ExtensibilityEssentialsCode>VSTK001</ExtensibilityEssentialsCode>
+      <ExtensibilityEssentialsHelpLink Condition="'$(VisualStudioVersion)' == '15.0'">https://marketplace.visualstudio.com/items?itemName=MadsKristensen.ExtensibilityEssentials</ExtensibilityEssentialsHelpLink>
+      <ExtensibilityEssentialsHelpLink Condition="'$(VisualStudioVersion)' == '16.0'">https://marketplace.visualstudio.com/items?itemName=MadsKristensen.ExtensibilityEssentials2019</ExtensibilityEssentialsHelpLink>
+    
+      <!-- Default level. -->
+      <ExtensibilityEssentialsLevel Condition="'$(ExtensibilityEssentialsLevel)' == ''">Info</ExtensibilityEssentialsLevel>
+      
+      <!-- 
+      Visibility Calculation. Only show the message, warning or error when building 
+      inside Visual Studio so that we don't break command line builds (because the 
+      extension won't be able to provide the `ExtensibilityEssentialsInstalled` property).
+      Also omit the message for CI builds, just in case Visual Studio is being used for CI. 
+      -->
+      <IsExtensibilityEssentialsMissing Condition="'$(CI)' == '' and '$(BuildingInsideVisualStudio)' == 'true' and '$(ExtensibilityEssentialsInstalled)' != 'true'">true</IsExtensibilityEssentialsMissing>
+    </PropertyGroup>
+
+    <!-- 
+    Verify that a valid "level" has been specified. This protects against the 
+    user making a mistake and not realizing that the message will never be shown.
+    -->
+    <Warning
+      Condition="'$(ExtensibilityEssentialsLevel)' != 'None' and '$(ExtensibilityEssentialsLevel)' != 'Info' and '$(ExtensibilityEssentialsLevel)' != 'Warning' and '$(ExtensibilityEssentialsLevel)' != 'Error'"
+      Text="The 'ExtensibilityEssentialsLevel' property value '$(ExtensibilityEssentialsLevel)' is invalid. Valid values are 'None', 'Info', 'Warning' or 'Error'."
+      />
+    
+    <!-- 
+    Messages marked as `IsCritical` appear in Visual Studio's Error List under the 'Messages' tab. 
+    Note that the Message task does not support the `HelpLink` property. :(
+    -->
+    <Message
+      Condition="'$(IsExtensibilityEssentialsMissing)' == 'true' and '$(ExtensibilityEssentialsLevel)' == 'Info'"
+      Text="$(ExtensibilityEssentialsInfoText)"
+      Code="$(ExtensibilityEssentialsCode)"
+      IsCritical="true"
+      />
+    
+    <!-- For MSBuild versions that do not support `HelpLink`. -->
+    <Warning 
+      Condition="'$(WarningsAndErrorsHaveHelpLink)' != 'true' and '$(IsExtensibilityEssentialsMissing)' == 'true' and '$(ExtensibilityEssentialsLevel)' == 'Warning'" 
+      Text="$(ExtensibilityEssentialsWarningText)" 
+      Code="$(ExtensibilityEssentialsCode)"
+      />
+
+    <Error 
+      Condition="'$(WarningsAndErrorsHaveHelpLink)' != 'true' and '$(IsExtensibilityEssentialsMissing)' == 'true' and '$(ExtensibilityEssentialsLevel)' == 'Error'" 
+      Text="$(ExtensibilityEssentialsErrorText)" 
+      Code="$(ExtensibilityEssentialsCode)"
+      />
+      
+    <!-- For MSBuild versions that support `HelpLink`. -->
+    <Warning 
+      Condition="'$(WarningsAndErrorsHaveHelpLink)' == 'true' and '$(IsExtensibilityEssentialsMissing)' == 'true' and '$(ExtensibilityEssentialsLevel)' == 'Warning'" 
+      Text="$(ExtensibilityEssentialsWarningText)" 
+      Code="$(ExtensibilityEssentialsCode)"
+      HelpLink="$(ExtensibilityEssentialsHelpLink)"
+      />
+
+    <Error 
+      Condition="'$(WarningsAndErrorsHaveHelpLink)' == 'true' and '$(IsExtensibilityEssentialsMissing)' == 'true' and '$(ExtensibilityEssentialsLevel)' == 'Error'" 
+      Text="$(ExtensibilityEssentialsErrorText)" 
+      Code="$(ExtensibilityEssentialsCode)"
+      HelpLink="$(ExtensibilityEssentialsHelpLink)"
+      />
+  </Target>
+
+</Project>

--- a/src/Community.VisualStudio.Toolkit.targets
+++ b/src/Community.VisualStudio.Toolkit.targets
@@ -2,6 +2,18 @@
 <Project>
 
   <Target Name="ExtensibilityEssentialsCheck" BeforeTargets="PrepareForBuild">
+    <ItemGroup>
+      <!-- 
+      We only want to check if the Extensibility Essentials extension is installed for VSIX projects,
+      because that is the only type of projects that the extension will add the build property for.
+      This requires two steps because we cannot filter an item group as it's created from a property.
+      First, turn the `ProjectTypeGuids` property into a set of items, then create another set by 
+      filtering out any types that are not the VSIX project type. 
+      -->
+      <ExtensibilityEssentialsProjectTypes Include="$(ProjectTypeGuids)"/>
+      <ExtensibilityEssentialsVsixProjectTypes Include="@(ExtensibilityEssentialsProjectTypes)" Condition="'%(Identity)' == '{82b43b9b-a64c-4715-b499-d71e9ca2bd60}'"/>
+    </ItemGroup>
+
     <PropertyGroup>
       <!-- 
       Determine whether a `HelpLink` property is supported on Warning and Error tasks. 
@@ -25,14 +37,15 @@
     
       <!-- Default level. -->
       <ExtensibilityEssentialsLevel Condition="'$(ExtensibilityEssentialsLevel)' == ''">Info</ExtensibilityEssentialsLevel>
-      
-      <!-- 
-      Visibility Calculation. Only show the message, warning or error when building 
-      inside Visual Studio so that we don't break command line builds (because the 
-      extension won't be able to provide the `ExtensibilityEssentialsInstalled` property).
+
+      <!--
+      Visibility Calculation. Only show the message, warning or error for VSIX projects, and only
+      when building them inside Visual Studio so that we don't break command line builds (because
+      the extension won't be able to provide the `ExtensibilityEssentialsInstalled` property).
       Also omit the message for CI builds, just in case Visual Studio is being used for CI. 
       -->
-      <IsExtensibilityEssentialsMissing Condition="'$(CI)' == '' and '$(BuildingInsideVisualStudio)' == 'true' and '$(ExtensibilityEssentialsInstalled)' != 'true'">true</IsExtensibilityEssentialsMissing>
+      <IsVsixProject Condition="'@(ExtensibilityEssentialsVsixProjectTypes->Count())' &gt; 0">true</IsVsixProject>
+      <IsExtensibilityEssentialsMissing Condition="'$(IsVsixProject)' == 'true' and '$(CI)' == '' and '$(BuildingInsideVisualStudio)' == 'true' and '$(ExtensibilityEssentialsInstalled)' != 'true'">true</IsExtensibilityEssentialsMissing>
     </PropertyGroup>
 
     <!-- 


### PR DESCRIPTION
From this discussion: https://github.com/VsixCommunity/Community.VisualStudio.Toolkit/discussions/13

This is the build target part. I'll leave this PR as a draft until the extension is written, which I aim to do this weekend. 🥳 

### Notes
* There are four different message levels that can be specified in the `ExtensibilityEssentialsLevel` build property:
   * `None` disables it.
   * `Info` (the default) produces a message.
   * `Warning` produces a build warning.
   * `Error` produces a build error.
* Any other value will produce a build warning telling you that the value is invalid.
* In Visual Studio 2019 (16.8+), the clickable link in the error list for _warnings and errors_ will take you to the marketplace page for the extension.
* For messages (the `Info` level), it's not possible to specify a link at this stage (see https://github.com/dotnet/msbuild/issues/6383)
* For Visual Studio 2017, a link cannot be provided, because that ability was only added in MSBuild 16.8 😢 (I assume it's not possible to make VS 2017 use a newer version of MSBuild).
* The message won't appear when building from MSBuild on the command line, or when building inside Visual Studio in a Continuous Integration environment (the message is suppressed when the `CI` environment variable is present).
* The message text can be overridden if you want to customize the message.

![extensibility-essentials-message](https://user-images.githubusercontent.com/10321525/116540965-305e2c80-a92e-11eb-9889-092e7f7f5aca.gif)
