### PR TITLE
Add capability to BaseOptionModel to alter the default collection nam…

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/Options/OverrideCollectionNameAttribute.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Options/OverrideCollectionNameAttribute.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Microsoft.VisualStudio.Settings;
+
+namespace Community.VisualStudio.Toolkit
+{
+    /// <summary>   Apply this attribute on an individual get/set property in your <see cref="BaseOptionModel{T}"/> 
+    ///             derived class to use a specific <c>CollectionName</c> to store a given property in the 
+    ///             <see cref="WritableSettingsStore"/> rather than using the <see cref="BaseOptionModel{T}.CollectionName"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
+    public class OverrideCollectionNameAttribute : Attribute
+    {
+        /// <summary>   Specifies the <c>CollectionName</c> in the <see cref="WritableSettingsStore"/> where
+        ///             this setting is stored rather than using the default, which is the <c>FullName</c>
+        ///             of the typeparam <c>T</c>. </summary>
+        /// <param name="collectionName">   This value is used as the <c>collectionPath</c> parameter when reading 
+        ///                                 and writing using the <see cref="WritableSettingsStore"/>.  </param>
+        public OverrideCollectionNameAttribute(string collectionName)
+        {
+            CollectionName = collectionName;
+        }
+
+        /// <summary>   This value is used as the <c>collectionPath</c> parameter when reading
+        ///             and writing using the <see cref="WritableSettingsStore"/>.  </summary>
+        public string CollectionName { get; }
+    }
+}

--- a/src/Community.VisualStudio.Toolkit.Shared/Options/OverrideDataTypeAttribute.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Options/OverrideDataTypeAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Microsoft.VisualStudio.Settings;
+
+namespace Community.VisualStudio.Toolkit
+{
+    /// <summary>   Apply this attribute on a get/set property in the <see cref="BaseOptionModel{T}"/> class to 
+    ///             alter the default mechanism used to store/retrieve the value of this property from the
+    ///             <see cref="WritableSettingsStore"/>. If not specified, the <see cref="SettingDataType"/><c>.Serialized</c>
+    ///             mechanism is used.  </summary>
+    [AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
+    public class OverrideDataTypeAttribute : Attribute
+    {
+        /// <summary>   Alters the default mechanism used to store/retrieve the value of this property from the setting store. </summary>
+        /// <param name="settingDataType">  Specifies the type and/or method used to store and retrieve the value of the attributed 
+        ///                                 property in the <see cref="WritableSettingsStore"/>. </param>
+        public OverrideDataTypeAttribute(SettingDataType settingDataType)
+        {
+            SettingDataType = settingDataType;
+        }
+
+        /// <summary>   Specifies the type and/or method used to store and retrieve the value of the attributed
+        ///             property in the <see cref="WritableSettingsStore"/>.</summary>
+        public SettingDataType SettingDataType { get; }
+    }
+}

--- a/src/Community.VisualStudio.Toolkit.Shared/Options/SettingDataType.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Options/SettingDataType.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.VisualStudio.Settings;
+
+namespace Community.VisualStudio.Toolkit
+{
+    /// <summary>   Enumeration that specifies the underlying type that is to be stored/retrieved from the
+    ///             <see cref="WritableSettingsStore"/>.  </summary>
+    public enum SettingDataType
+    {
+        /// <summary>   Uses the <see cref="WritableSettingsStore"/>.<see cref="WritableSettingsStore.SetString"/>
+        /// to update the value of the attributed property (of any <see cref="Type.IsSerializable"/> type), using 
+        /// an underlying string type in the settings store. The raw value of the property is first serialized 
+        /// to a string for storage, using the means specified in <see cref="BaseOptionModel{T}"/>. This differs
+        /// from <see cref="String"/> because with this option the underlying type IS ALWAYS serialized prior 
+        /// to storage. </summary>
+        Serialized,
+        /// <summary>   Uses the <see cref="WritableSettingsStore"/>.<see cref="WritableSettingsStore.SetString"/>
+        /// to update the value of the attributed <see cref="string"/> property, using an underlying string type
+        /// in the settings store. This differs from <see cref="Serialized"/> because with this option the raw 
+        /// string is stored and IS NEVER serialized. </summary>
+        String,
+        /// <summary>   Uses the <see cref="WritableSettingsStore"/>.<see cref="WritableSettingsStore.SetBoolean"/>
+        /// to update the value of the attributed <see cref="bool"/> property, using an underlying Int32 type 
+        /// in the settings store. </summary>
+        Bool,
+        /// <summary>   Uses the <see cref="WritableSettingsStore"/>.<see cref="WritableSettingsStore.SetInt32"/>
+        /// to update the value of the attributed <see cref="Int32"/> property, using an underlying Int32 type
+        /// in the settings store. </summary>
+        Int32,
+        /// <summary>   Uses the <see cref="WritableSettingsStore"/>.<see cref="WritableSettingsStore.SetUInt32"/>
+        /// to update the value of the attributed <see cref="UInt32"/> property, using an underlying UInt32 type
+        /// in the settings store. </summary>
+        UInt32,
+        /// <summary>   Uses the <see cref="WritableSettingsStore"/>.<see cref="WritableSettingsStore.SetInt64"/>
+        /// to update the value of the attributed <see cref="Int64"/> property, using an underlying Int64 type
+        /// in the settings store. </summary>
+        Int64,
+        /// <summary>   Uses the <see cref="WritableSettingsStore"/>.<see cref="WritableSettingsStore.SetUInt64"/>
+        /// to update the value of the attributed <see cref="UInt64"/> property, using an underlying UInt64 type
+        /// in the settings store. </summary>
+        UInt64,
+    }
+}

--- a/src/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
+++ b/src/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
@@ -21,6 +21,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\TaskExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\TextBufferExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ProjectTypes.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Options\OverrideCollectionNameAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Options\OverrideDataTypeAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Options\SettingDataType.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Themes\ToolkitResourceKeys.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Themes\Themes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Notifications\MessageBox.cs" />


### PR DESCRIPTION
…e per-property via the use of an attribute. Add capability to BaseOptionModel to alter the default storage mechanism per property of 'serialize to string' to instead use the built-in SettingsStore supported types (string, bool, int, uint, long, ulong) via the use of an attribute. Add more in-depth documentation and logging to BaseOptionModel. Add overloads to ExceptionExtensions for logging messages or formatted strings along with the exception.

These changes are helpful for porting existing extensions to the toolkit where settings were stored using their underlying type and not serialized to base64 strings.