### PR TITLE
Added extension methods for saving the solution.

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/SolutionExtensions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/SolutionExtensions.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
 
 namespace EnvDTE
 {
@@ -28,6 +30,39 @@ namespace EnvDTE
                 // Returns 'true' if the number of failed projects == 0
                 buildTaskCompletionSource.TrySetResult(dte.Solution.SolutionBuild.LastBuildInfo == 0);
             }
+        }
+
+        /// <summary>
+        /// Saves the solution
+        /// Although this method is asynchronous, the saving of the solution is still synchronous and is performed on the main UI thread.
+        /// </summary>
+        /// <param name="solution"></param>
+        /// <returns></returns>
+        public static async Task SaveAsync(this Solution solution)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            if (solution == null)
+                throw new ArgumentNullException(nameof(solution));
+
+            solution.SaveAs(solution.FileName);
+        }
+
+        /// <summary>
+        /// Saves the solution with the specified name
+        /// Although this method is asynchronous, the saving of the solution is still synchronous and is performed on the main UI thread.
+        /// </summary>
+        /// <param name="solution"></param>
+        /// <param name="fileName"></param>
+        /// <returns></returns>
+        public static async Task SaveAsAsync(this Solution solution, string fileName)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            if (solution == null)
+                throw new ArgumentNullException(nameof(solution));
+
+            solution.SaveAs(fileName);
         }
     }
 }

--- a/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/SolutionExtensions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/SolutionExtensions.cs
@@ -33,7 +33,7 @@ namespace EnvDTE
         }
 
         /// <summary>
-        /// Saves the solution
+        /// Saves the solution.
         /// Although this method is asynchronous, the saving of the solution is still synchronous and is performed on the main UI thread.
         /// </summary>
         /// <param name="solution"></param>
@@ -49,7 +49,7 @@ namespace EnvDTE
         }
 
         /// <summary>
-        /// Saves the solution with the specified name
+        /// Saves the solution with the specified name.
         /// Although this method is asynchronous, the saving of the solution is still synchronous and is performed on the main UI thread.
         /// </summary>
         /// <param name="solution"></param>

--- a/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/SolutionExtensions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/SolutionExtensions.cs
@@ -42,10 +42,7 @@ namespace EnvDTE
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            if (solution == null)
-                throw new ArgumentNullException(nameof(solution));
-
-            solution.SaveAs(solution.FileName);
+            await solution.SaveAsAsync(solution.FileName);
         }
 
         /// <summary>


### PR DESCRIPTION
These are certainly not ground breaking... the `SaveAsync` at least simplifies it for newcomers (don't need to pass in the name of the solution).  Really this is more about setting forth what the "ideal" would be which is to have an async version of being able to save the solution.  This at least brings that to the forefront as well as ensures that for now it's being handled properly by executing on the UI thread.