### PR TITLE
ToolkitThreadHelper - a safe JoinableTaskFactory for MEF components (and other cases where package JTF not available)

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/ToolkitThreadHelper.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ToolkitThreadHelper.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Threading;
+using Microsoft.VisualStudio.Threading;
+
+namespace Community.VisualStudio.Toolkit.Shared
+{
+    /// <summary>
+    /// Provides a JoinableTaskFactory that is safe to use in MEF components or when an AsyncPackage.JoinableTaskFactory
+    /// is not available.
+    /// </summary>
+    /// <remarks>
+    /// JoinableTaskFactory (hereafter 'JTF') from ThreadHelper is not the same as from an AsyncPackage. If you have an
+    /// AsyncPackage available then always prefer to use its JTF instance over ThreadHelper. AsyncPackage's JTF will
+    /// track all unjoined tasks and ensure they get joined when the package disposes before VS shuts down the CLR.
+    /// 
+    /// In addition, AsyncPackage provides a disposal token so if you pass that token to all your async work (which you
+    /// should) then VS can signal the token to cancel all work and ensure shutdown happens quickly, instead of having
+    /// to wait for unfinished tasks to complete.
+    ///
+    /// But in some places (e.g. MEF components) you won't have an AsyncPackage available and may be tempted to use
+    /// ThreadHelper's JTF. That's fine for Run and SwitchToMainThreadAsync and also for RunAsync as long as you
+    /// await/join all tasks that RunAsync returns (although you still won't have a disposal token). But if you start
+    /// fire-and-forget style tasks using ThreadHelper.JoinableTaskFactory.RunAsync and never explicitly await/join them
+    /// then these tasks will never be joined.
+    /// 
+    /// ToolkitThreadHelper solves the above by creating a new JTF instance along with a collection and a disposal token,
+    /// and ensures that all unfinished tasks are joined during disposal, just like AsyncPackage.
+    /// 
+    /// The implementation is based on aarnott's example here:
+    /// https://github.com/microsoft/vs-threading/blob/main/doc/cookbook_vs.md#void-returning-fire-and-forget-methods
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// [Export(typeof(IWpfTextViewCreationListener))]
+    /// class TextviewCreationListener : IWpfTextViewCreationListener, IDisposable
+    /// {
+    ///     private readonly ToolkitThreadHelper _threadHelper = new(ThreadHelper.JoinableTaskContext);
+    ///     
+    ///     public void Dispose()
+    ///     {
+    ///         Dispose(true);
+    ///         GC.SuppressFinalize(this);
+    ///     }
+    ///     
+    ///     protected virtual void Dispose(bool disposing)
+    ///     {
+    ///         if (disposing)
+    ///         {
+    ///             _threadHelper.Dispose();
+    ///         }   
+    ///     }
+    /// 
+    ///     public void TextViewCreated(IWpfTextView textView)
+    ///     {
+    ///         // Note: RunAsync not awaited
+    ///         _threadHelper.JoinableTaskFactory.RunAsync(async () =>
+    ///         {
+    ///             try
+    ///             {
+    ///                 await _threadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(_threadHelper.DisposalToken);
+    ///                 
+    ///                 await MyMethodAsync(_threadHelper.DisposalToken);
+    ///             }
+    ///             catch (Exception ex)
+    ///             {
+    ///                 await ex.LogAsync();
+    ///             }
+    ///         });
+    ///     }
+    /// }
+    /// </code>
+    /// </example>
+    public class ToolkitThreadHelper : IDisposable
+    {
+        private readonly CancellationTokenSource _disposeCancellationTokenSource = new();
+        private readonly JoinableTaskContext _context;
+        private readonly JoinableTaskCollection _collection;
+        private bool _disposed = false;
+
+        /// <summary>
+        /// Creates the ToolkitThreadHelper.
+        /// </summary>
+        /// <param name="joinableTaskContext">
+        /// The application's one-and-only <see cref="JoinableTaskContext"/>.
+        /// For VS extensions, pass ThreadHelper.JoinableTaskContext, which is Visual Studio's singleton instance.
+        /// For unit tests, create a JoinableTaskContext instance (only one instance for the process) to supply here.
+        /// </param>
+        public ToolkitThreadHelper(JoinableTaskContext joinableTaskContext)
+        {
+            _context = joinableTaskContext;
+            _collection = joinableTaskContext.CreateCollection();
+            JoinableTaskFactory = joinableTaskContext.CreateFactory(_collection);
+        }
+
+        /// <summary>
+        /// The JoinableTaskFactory instance.
+        /// </summary>
+        public JoinableTaskFactory JoinableTaskFactory { get; }
+
+        /// <summary>
+        /// Gets a <see cref="CancellationToken"/> that can be used to check if the class has been disposed.
+        /// </summary>
+        public CancellationToken DisposalToken => _disposeCancellationTokenSource.Token;
+
+        /// <summary>
+        /// Joins any unfinished tasks.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Joins any unfinished tasks.
+        /// </summary>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed && disposing)
+            {
+                _disposeCancellationTokenSource.Cancel();
+
+                try
+                {
+                    // Block Dispose until all async work has completed.
+                    _context.Factory.Run(_collection.JoinTillEmptyAsync);
+                }
+                catch (OperationCanceledException)
+                {
+                    // this exception is expected because we signaled the cancellation token
+                }
+                catch (AggregateException ex)
+                {
+                    // ignore AggregateException containing only OperationCanceledException
+                    ex.Handle(inner => (inner is OperationCanceledException));
+                }
+                finally
+                {
+                    _disposeCancellationTokenSource.Dispose();
+                    _disposed = true;
+                }
+            }
+        }
+    }
+}

--- a/src/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
+++ b/src/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
@@ -22,6 +22,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\TextBufferExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ContentTypes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ProjectTypes.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ToolkitThreadHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Options\OverrideCollectionNameAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Options\OverrideDataTypeAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Options\SettingDataType.cs" />

--- a/test/VSSDK.TestExtension/MEF/TextviewCreationListener.cs
+++ b/test/VSSDK.TestExtension/MEF/TextviewCreationListener.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.ComponentModel.Composition;
+using Community.VisualStudio.Toolkit.Shared;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Utilities;
+
+namespace TestExtension.MEF
+{
+    [Export(typeof(IWpfTextViewCreationListener))]
+    [ContentType("text")]
+    [TextViewRole(PredefinedTextViewRoles.PrimaryDocument)]
+    internal class TextviewCreationListener : IWpfTextViewCreationListener, IDisposable
+    {
+        private readonly ToolkitThreadHelper _threadHelper = new ToolkitThreadHelper(ThreadHelper.JoinableTaskContext);
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _threadHelper.Dispose();
+            }
+        }
+
+        public void TextViewCreated(IWpfTextView textView)
+        {
+            // Note: RunAsync is not awaited/joined
+            _threadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                try
+                {
+                    await _threadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(_threadHelper.DisposalToken);
+
+                    // Do work, e.g.
+                    // await MyMethodAsync(_threadHelper.DisposalToken);
+                }
+                catch (Exception ex)
+                {
+                    await ex.LogAsync();
+                }
+            });
+        }
+    }
+}

--- a/test/VSSDK.TestExtension/VSSDK.TestExtension.csproj
+++ b/test/VSSDK.TestExtension/VSSDK.TestExtension.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Commands\MultiInstanceWindowCommand.cs" />
     <Compile Include="Commands\RunnerWindowCommand.cs" />
     <Compile Include="Commands\ThemeWindowCommand.cs" />
+    <Compile Include="MEF\TextviewCreationListener.cs" />
     <Compile Include="Options\General.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ToolWindows\MultiInstanceWindow.cs" />
@@ -88,6 +89,7 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Design" />
     <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />

--- a/test/VSSDK.TestExtension/source.extension.vsixmanifest
+++ b/test/VSSDK.TestExtension/source.extension.vsixmanifest
@@ -1,20 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="VSSDK.TestExtension.5a9a059d-5738-41dc-9075-250890b4ef6f" Version="1.0" Language="en-US" Publisher="Mads Kristensen" />
-    <DisplayName>VSSDK.TestExtension</DisplayName>
-    <Description>Empty VSIX Project.</Description>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-  </Dependencies>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-  </Assets>
+    <Metadata>
+        <Identity Id="VSSDK.TestExtension.5a9a059d-5738-41dc-9075-250890b4ef6f" Version="1.0" Language="en-US" Publisher="Mads Kristensen" />
+        <DisplayName>VSSDK.TestExtension</DisplayName>
+        <Description>Empty VSIX Project.</Description>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    </Dependencies>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+    </Assets>
 </PackageManifest>


### PR DESCRIPTION
Added:

- ToolkitThreadHelper.cs in Toolkit.Shared
- TextviewCreationListener.cs in the TestExtension 

`ToolkitThreadHelper` provides a `JoinableTaskFactory` that is safe to use in MEF components or when an `AsyncPackage.JoinableTaskFactory` is not available.

Usage example:

```
[Export(typeof(IWpfTextViewCreationListener))]
[ContentType("text")]
[TextViewRole(PredefinedTextViewRoles.PrimaryDocument)]
internal class TextviewCreationListener : IWpfTextViewCreationListener, IDisposable
{
    private readonly ToolkitThreadHelper _threadHelper = new ToolkitThreadHelper(ThreadHelper.JoinableTaskContext);

    public void Dispose()
    {
        Dispose(true);
        GC.SuppressFinalize(this);
    }

    protected virtual void Dispose(bool disposing)
    {
        if (disposing)
        {
            _threadHelper.Dispose();
        }
    }

    public void TextViewCreated(IWpfTextView textView)
    {
        // Note: RunAsync is not awaited/joined
        _threadHelper.JoinableTaskFactory.RunAsync(async () =>
        {
            try
            {
                await _threadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(_threadHelper.DisposalToken);

                // Do work, e.g.
                // await MyMethodAsync(_threadHelper.DisposalToken);
            }
            catch (Exception ex)
            {
                await ex.LogAsync();
            }
        });
    }
}
```

`JoinableTaskFactory` (hereafter 'JTF') from `ThreadHelper` is not the same as from an `AsyncPackage`. If you have an AsyncPackage available then always prefer to use its JTF instance over ThreadHelper. AsyncPackage's JTF will track all unjoined tasks and ensure they get joined when the package disposes before VS shuts down the CLR.
 
 In addition, AsyncPackage provides a disposal token so if you pass that token to all your async work (which you should) then VS can signal the token to cancel all work and ensure shutdown happens quickly, instead of having to wait for unfinished tasks to complete.

 But in some places (e.g. MEF components) you won't have an AsyncPackage available and may be tempted to use ThreadHelper's JTF. That's fine for Run and SwitchToMainThreadAsync and also for RunAsync as long as you await/join all tasks that RunAsync returns (although you still won't have a disposal token). But if you start fire-and-forget style tasks using `ThreadHelper.JoinableTaskFactory.RunAsync` and never explicitly await/join them then these tasks will never be joined.
 
 ToolkitThreadHelper solves the above by creating a new JTF instance along with a collection and a disposal token, and ensures that all unfinished tasks are joined during disposal, just like AsyncPackage.
 
 The implementation is based on aarnott's example here:
 https://github.com/microsoft/vs-threading/blob/main/doc/cookbook_vs.md#void-returning-fire-and-forget-methods