### PR TITLE
Changes to ToolkitThreadHelper & TextViewCreationListener and new ForgetAndLogOnFailure overload for JoinableTask

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/TaskExtensions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/TaskExtensions.cs
@@ -5,13 +5,17 @@ using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.Shell
 {
-    /// <summary>Extension methods for the <see cref="System.Threading.Tasks.Task" /> object.</summary>
+    /// <summary>
+    /// Extension methods for <see cref="System.Threading.Tasks.Task" /> and <see cref="JoinableTask" />.
+    /// </summary>
     public static class TaskExtensions
     {
         /// <summary>
-        /// Starts a Task and lets it run in the background, while silently handles any exceptions.
+        /// Logs error information to the Output Window if the given <see cref="System.Threading.Tasks.Task" /> faults.
         /// </summary>
         /// <remarks>
+        /// The task itself starts before this extension method is called and only continues in
+        /// this extension method if the original task throws an unhandled exception.
         /// This is similar to the <c>task.Forget()</c> method, but it logs any unhandled exception
         /// thrown from the task to the Output Window.
         /// </remarks>
@@ -22,6 +26,17 @@ namespace Microsoft.VisualStudio.Shell
                 antecedent.Exception!.Log();
 
             }, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default).Forget();
+        }
+
+        /// <summary>
+        /// Logs error information to the Output Window if the given <see cref="JoinableTask" /> faults.
+        /// </summary>
+        /// <remarks>
+        /// This is the JoinableTask equivalent of <see cref="ForgetAndLogOnFailure(System.Threading.Tasks.Task)"/>
+        /// </remarks>
+        public static void ForgetAndLogOnFailure(this JoinableTask joinableTask)
+        {
+            ForgetAndLogOnFailure(joinableTask.Task);
         }
     }
 }

--- a/test/VSSDK.TestExtension/MEF/TextviewCreationListener.cs
+++ b/test/VSSDK.TestExtension/MEF/TextviewCreationListener.cs
@@ -12,7 +12,7 @@ namespace TestExtension.MEF
     [TextViewRole(PredefinedTextViewRoles.PrimaryDocument)]
     internal class TextViewCreationListener : IWpfTextViewCreationListener, IDisposable
     {
-        private readonly ToolkitThreadHelper _threadHelper = new ToolkitThreadHelper(ThreadHelper.JoinableTaskContext);
+        private readonly ToolkitThreadHelper _threadHelper = ToolkitThreadHelper.Create();
 
         public void Dispose()
         {
@@ -33,18 +33,12 @@ namespace TestExtension.MEF
             // Note: RunAsync is not awaited/joined
             _threadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                try
-                {
-                    await _threadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(_threadHelper.DisposalToken);
+                await _threadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(_threadHelper.DisposalToken);
 
-                    // Do work, e.g.
-                    // await MyMethodAsync(_threadHelper.DisposalToken);
-                }
-                catch (Exception ex)
-                {
-                    await ex.LogAsync();
-                }
-            });
+                // Do work, e.g.
+                // await MyMethodAsync(_threadHelper.DisposalToken);
+
+            }).ForgetAndLogOnFailure();
         }
     }
 }

--- a/test/VSSDK.TestExtension/MEF/TextviewCreationListener.cs
+++ b/test/VSSDK.TestExtension/MEF/TextviewCreationListener.cs
@@ -10,7 +10,7 @@ namespace TestExtension.MEF
     [Export(typeof(IWpfTextViewCreationListener))]
     [ContentType("text")]
     [TextViewRole(PredefinedTextViewRoles.PrimaryDocument)]
-    internal class TextviewCreationListener : IWpfTextViewCreationListener, IDisposable
+    internal class TextViewCreationListener : IWpfTextViewCreationListener, IDisposable
     {
         private readonly ToolkitThreadHelper _threadHelper = new ToolkitThreadHelper(ThreadHelper.JoinableTaskContext);
 

--- a/test/VSSDK.TestExtension/VSSDK.TestExtension.csproj
+++ b/test/VSSDK.TestExtension/VSSDK.TestExtension.csproj
@@ -50,7 +50,7 @@
     <Compile Include="Commands\MultiInstanceWindowCommand.cs" />
     <Compile Include="Commands\RunnerWindowCommand.cs" />
     <Compile Include="Commands\ThemeWindowCommand.cs" />
-    <Compile Include="MEF\TextviewCreationListener.cs" />
+    <Compile Include="MEF\TextViewCreationListener.cs" />
     <Compile Include="Options\General.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ToolWindows\MultiInstanceWindow.cs" />


### PR DESCRIPTION
Changes after code review:
* New ForgetAndLogOnFailure(JoinableTask) overload
* Replaced ToolkitThreadHelper ctor with two static factory methods
* TextViewCreationListener (example of how to use new ToolkitThreadHelper) now uses ForgetAndLogOnFailure
* Fixed TextViewCreationListener case