### PR TITLE
OutputWindowPane

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/Helpers/OutputWindowPane.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Helpers/OutputWindowPane.cs
@@ -1,0 +1,276 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+using Task = System.Threading.Tasks.Task;
+
+namespace Community.VisualStudio.Toolkit.Shared.Helpers
+{
+    /// <summary>
+    /// A pane in the Output window.
+    /// </summary>
+    /// <remarks>
+    /// OutputWindowPane allows an extension to create a new Output window pane or get an existing one.
+    /// A pane can be activated (shown), hidden and cleared. Text can be written to the pane via methods
+    /// like <see cref="WriteLineAsync(string)"/> or with a <see cref="TextWriter"/> returned
+    /// from <see cref="CreateOutputPaneTextWriterAsync"/>.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// Guid myPaneGuid;
+    /// {
+    ///     OutputWindowPane pane = await VS.Windows.CreateOutputWindowPaneAsync("My Pane");
+    ///     myPaneGuid = pane.Guid;
+    ///     await pane.WriteLineAsync("My message");
+    /// }
+    /// 
+    /// // Elsewhere:
+    /// {
+    ///     OutputWindowPane pane = await VS.Windows.GetOutputWindowPaneAsync(myPaneGuid);
+    ///     pane.Name = "My Pane - Updated";
+    ///     using (TextWriter writer = await pane.CreateOutputPaneTextWriterAsync())
+    ///     {
+    ///         char[] buffer = GetSomeChars();
+    ///         await writer.WriteLineAsync("This is a more efficient way to write lots of text.");
+    ///         await writer.WriteAsync(buffer, 0, buffer.Length);
+    ///         await writer.WriteLineAsync();
+    ///     }
+    /// }
+    /// </code>
+    /// </example>
+    public class OutputWindowPane
+    {
+        private readonly string _newPaneName;
+        private IVsOutputWindowPane? _pane;
+
+        /// <summary>
+        /// Creates a new Output window pane with the given name (title).
+        /// The new pane can be created at construction time or lazily upon first write.
+        /// </summary>
+        /// <param name="name">The name (title) of the new pane.</param>
+        /// <param name="lazyCreate">Whether to lazily create the pane upon first write.</param>
+        /// <returns>A new OutputWindowPane.</returns>
+        public static async Task<OutputWindowPane> CreateAsync(string name, bool lazyCreate = true)
+        {
+            if (string.IsNullOrEmpty(name))
+                throw new ArgumentException(nameof(name));
+
+            var pane = new OutputWindowPane(name, Guid.NewGuid());
+
+            if (!lazyCreate)
+            {
+                await pane.EnsurePaneAsync();
+            }
+
+            return pane;
+        }
+
+        /// <summary>
+        /// Gets an existing Output window pane.
+        /// Throws if a pane with the specified guid does not exist.
+        /// </summary>
+        /// <param name="guid">The pane's unique identifier.</param>
+        /// <returns>A new OutputWindowPane.</returns>
+        public static async Task<OutputWindowPane> GetAsync(Guid guid)
+        {
+            // Empty string for `_name` signals to EnsurePaneAsync that we want to get an existing pane.
+            var pane = new OutputWindowPane(string.Empty, guid);
+
+            await pane.EnsurePaneAsync();
+
+            return pane;
+        }
+
+        /// <summary>
+        /// Uniquely identifies the Output window pane.
+        /// After creating a pane, you can cache this Guid and later obtain the same pane from <see cref="GetAsync(Guid)"/>.
+        /// </summary>
+        public Guid Guid { get; }
+
+        /// <summary>
+        /// The name (title) of the Output window pane.
+        /// </summary>
+        public string Name
+        {
+            get
+            {
+                return ThreadHelper.JoinableTaskFactory.Run(async () =>
+                {
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                    await EnsurePaneAsync();
+
+                    if (_pane == null)
+                        throw new InvalidOperationException("IVsOutputWindowPane should exist");
+
+                    string name = string.Empty;
+                    _pane.GetName(ref name);
+                    return name;
+                });
+            }
+
+            set
+            {
+                ThreadHelper.JoinableTaskFactory.Run(async () =>
+                {
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                    await EnsurePaneAsync();
+
+                    if (_pane == null)
+                        throw new InvalidOperationException("IVsOutputWindowPane should exist");
+
+                    _pane.SetName(value);
+                });
+            }
+        }
+
+        /// <summary>
+        /// Shows and activates the Output window pane.
+        /// </summary>
+        public async Task ActivateAsync()
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            await EnsurePaneAsync();
+
+            if (_pane == null)
+                throw new InvalidOperationException("IVsOutputWindowPane should exist");
+
+            _pane.Activate();
+        }
+
+        /// <summary>
+        /// Hides the Output window pane.
+        /// </summary>
+        public async Task HideAsync()
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            await EnsurePaneAsync();
+
+            if (_pane == null)
+                throw new InvalidOperationException("IVsOutputWindowPane should exist");
+
+            _pane.Hide();
+        }
+
+        /// <summary>
+        /// Clears the Output window pane.
+        /// </summary>
+        public async Task ClearAsync()
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            await EnsurePaneAsync();
+
+            if (_pane == null)
+                throw new InvalidOperationException("IVsOutputWindowPane should exist");
+
+            _pane.Clear();
+        }
+
+        /// <summary>
+        /// Writes a new line to the Output window pane.
+        /// </summary>
+        public void WriteLine()
+        {
+            ThreadHelper.JoinableTaskFactory.Run(async () =>
+            {
+                await WriteLineAsync();
+            });
+        }
+
+        /// <summary>
+        /// Writes the given text followed by a new line to the Output window pane.
+        /// </summary>
+        /// <param name="value">The text value to write.</param>
+        public void WriteLine(string value)
+        {
+            ThreadHelper.JoinableTaskFactory.Run(async () =>
+            {
+                await WriteLineAsync(value);
+            });
+        }
+
+        /// <summary>
+        /// Writes a new line to the Output window pane.
+        /// </summary>
+        public Task WriteLineAsync()
+        {
+            return WriteLineAsync(string.Empty);
+        }
+
+        /// <summary>
+        /// Writes the given text followed by a new line to the Output window pane.
+        /// </summary>
+        /// <param name="value">The text value to write. May be an empty string, in which case a newline is written.</param>
+        public async Task WriteLineAsync(string value)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            await EnsurePaneAsync();
+
+            if (_pane == null)
+                throw new InvalidOperationException("IVsOutputWindowPane should exist");
+
+            _pane.OutputString(value + Environment.NewLine);
+        }
+
+        /// <summary>
+        /// Returns a new <see cref="TextWriter"/> that can be used to write text to the Output window pane.
+        /// For newer versions of Visual Studio this provides a more efficient way to write lots
+        /// of text to the pane.
+        /// </summary>
+        public async Task<TextWriter> CreateOutputPaneTextWriterAsync()
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            await EnsurePaneAsync();
+
+            if (_pane == null)
+                throw new InvalidOperationException("IVsOutputWindowPane should exist");
+
+#if VS16 || VS17
+            return new OutputWindowTextWriter(_pane);
+#else
+            return new OutputWindowTextWriterVS14(_pane);  // For VS15 too
+#endif
+        }
+
+        private async Task EnsurePaneAsync()
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            try
+            {
+                if (_pane == null)
+                {
+                    IVsOutputWindow output = await VS.Windows.GetOutputWindowAsync();
+                    Guid paneGuid = Guid;
+
+                    // Only create the pane if we were constructed with a non-empty `_newPaneName`.
+                    if (!string.IsNullOrEmpty(_newPaneName))
+                    {
+                        ErrorHandler.ThrowOnFailure(output.CreatePane(ref paneGuid, _newPaneName, 1, 1));
+                    }
+
+                    ErrorHandler.ThrowOnFailure(output.GetPane(ref paneGuid, out _pane));
+                }
+            }
+            catch (Exception ex)
+            {
+                ex.Log();
+            }
+        }
+
+        private OutputWindowPane(string newPaneName, Guid paneGuid)
+        {
+            _newPaneName = newPaneName;
+            Guid = paneGuid;
+        }
+    }
+}

--- a/src/Community.VisualStudio.Toolkit.Shared/Helpers/OutputWindowTextWriterVS14.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Helpers/OutputWindowTextWriterVS14.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Text;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Task = System.Threading.Tasks.Task;
+
+namespace Community.VisualStudio.Toolkit.Shared.Helpers
+{
+    /// <summary>
+    /// A <see cref="System.IO.TextWriter"/> that writes to an Output window pane.
+    /// This is suitable for use in Visual Studio 2015 and 2017 where OutputWindowTextWriter is not available.
+    /// Overrides the same methods on TextWriter that OutputWindowTextWriter does.
+    /// </summary>
+    internal class OutputWindowTextWriterVS14 : System.IO.TextWriter
+    {
+        private readonly IVsOutputWindowPane _pane;
+
+        /// <summary>
+        /// Creates the text writer.
+        /// </summary>
+        /// <param name="pane">The Output window pane.</param>
+        public OutputWindowTextWriterVS14(IVsOutputWindowPane pane)
+        {
+            _pane = pane;
+        }
+
+        /// <summary>
+        /// The character encoding in which the output is written.
+        /// </summary>
+        public override Encoding Encoding => Encoding.Default;
+
+        #region Write
+
+        /// <summary>
+        /// Writes text to the Output window pane.
+        /// </summary>
+        /// <param name="value">The text to write.</param>
+        public override void Write(string value)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            _pane.OutputString(value);
+        }
+
+        /// <summary>
+        /// Writes an array of characters to the Output window pane.
+        /// </summary>
+        /// <param name="buffer">The character array.</param>
+        /// <param name="index">Start index.</param>
+        /// <param name="count">Number of characters,</param>
+        public override void Write(char[] buffer, int index, int count)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            _pane.OutputString(new string(buffer, index, count));
+        }
+
+        #endregion
+
+        #region WriteAsync
+
+        /// <summary>
+        /// Writes text to the Output window pane.
+        /// </summary>
+        /// <param name="value">The text to write.</param>
+        public override async Task WriteAsync(string value)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            _pane.OutputString(value);
+        }
+
+        /// <summary>
+        /// Writes a character to the Output window pane.
+        /// </summary>
+        /// <param name="value">The character to write.</param>
+        public override async Task WriteAsync(char value)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            _pane.OutputString(value.ToString());
+        }
+
+        /// <summary>
+        /// Writes an array of characters to the Output window pane.
+        /// </summary>
+        /// <param name="buffer">The character array.</param>
+        /// <param name="index">Start index.</param>
+        /// <param name="count">Number of characters,</param>
+        public override async Task WriteAsync(char[] buffer, int index, int count)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            _pane.OutputString(new string(buffer, index, count));
+        }
+
+        #endregion
+
+        #region WriteLine
+
+        public override void WriteLine(string value)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            _pane.OutputString(value + Environment.NewLine);
+        }
+
+        #endregion
+
+        #region WriteLineAsync
+
+        /// <summary>
+        /// Writes an empty new line to the Output window pane.
+        /// </summary>
+        public override async Task WriteLineAsync()
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            _pane.OutputString(Environment.NewLine);
+        }
+
+        /// <summary>
+        /// Writes text followed by a new line to the Output window pane.
+        /// </summary>
+        /// <param name="value">The text to write.</param>
+        public override async Task WriteLineAsync(string value)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            _pane.OutputString(value + Environment.NewLine);
+        }
+
+        /// <summary>
+        /// Writes a character followed by a new line to the Output window pane.
+        /// </summary>
+        /// <param name="value">The character to write.</param>
+        public override async Task WriteLineAsync(char value)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            _pane.OutputString(value.ToString() + Environment.NewLine);
+        }
+
+        /// <summary>
+        /// Writes an array of characters followed by a new line to the Output window pane.
+        /// </summary>
+        /// <param name="buffer">The character array.</param>
+        /// <param name="index">Start index.</param>
+        /// <param name="count">Number of characters,</param>
+        public override async Task WriteLineAsync(char[] buffer, int index, int count)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            _pane.OutputString(new string(buffer, index, count) + Environment.NewLine);
+        }
+
+        #endregion
+    }
+}

--- a/src/Community.VisualStudio.Toolkit.Shared/Services/Windows.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Services/Windows.cs
@@ -12,6 +12,19 @@ namespace Community.VisualStudio.Toolkit
         internal Windows()
         { }
 
+        /// <summary>
+        /// Output window panes provided by Visual Studio.
+        /// </summary>
+        public enum VSOutputWindowPane
+        {
+            /// <summary>The General pane.</summary>
+            General,
+            /// <summary>The Build pane.</summary>
+            Build,
+            /// <summary>The Debug pane.</summary>
+            Debug
+        }
+
         /// <summary>Manipulates the Call Browser for debugging.</summary>
         public Task<IVsCallBrowser> GetCallBrowserAsync() => VS.GetServiceAsync<SVsCodeWindow, IVsCallBrowser>();
 
@@ -38,6 +51,15 @@ namespace Community.VisualStudio.Toolkit
         /// <param name="lazyCreate">Whether to lazily create the pane upon first write.</param>
         /// <returns>A new OutputWindowPane.</returns>
         public Task<OutputWindowPane> CreateOutputWindowPaneAsync(string name, bool lazyCreate = true) => OutputWindowPane.CreateAsync(name, lazyCreate);
+
+        /// <summary>
+        /// Gets an existing Visual Studio Output window pane (General, Build, Debug).
+        /// If the General pane does not already exist then it will be created, but that is not
+        /// the case for Build or Debug.
+        /// </summary>
+        /// <param name="pane">The Visual Studio pane to get.</param>
+        /// <returns>A new OutputWindowPane.</returns>
+        public Task<OutputWindowPane> GetOutputWindowPaneAsync(VSOutputWindowPane pane) => OutputWindowPane.GetAsync(pane);
 
         /// <summary>
         /// Gets an existing Output window pane.

--- a/src/Community.VisualStudio.Toolkit.Shared/Services/Windows.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Services/Windows.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
+using Community.VisualStudio.Toolkit.Shared.Helpers;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
 
@@ -27,6 +29,23 @@ namespace Community.VisualStudio.Toolkit
 
         /// <summary>Manages and controls functions specific to the Output tool window that has multiple panes.</summary>
         public Task<IVsOutputWindow> GetOutputWindowAsync() => VS.GetServiceAsync<SVsOutputWindow, IVsOutputWindow>();
+
+        /// <summary>
+        /// Creates a new Output window pane with the given name.
+        /// The pane can be created now or lazily upon the first write to it.
+        /// </summary>
+        /// <param name="name">The name (title) of the new pane.</param>
+        /// <param name="lazyCreate">Whether to lazily create the pane upon first write.</param>
+        /// <returns>A new OutputWindowPane.</returns>
+        public Task<OutputWindowPane> CreateOutputWindowPaneAsync(string name, bool lazyCreate = true) => OutputWindowPane.CreateAsync(name, lazyCreate);
+
+        /// <summary>
+        /// Gets an existing Output window pane.
+        /// Throws if a pane with the specified guid does not exist.
+        /// </summary>
+        /// <param name="guid">The pane's unique identifier.</param>
+        /// <returns>A new OutputWindowPane.</returns>
+        public Task<OutputWindowPane> GetOutputWindowPaneAsync(Guid guid) => OutputWindowPane.GetAsync(guid);
 
         /// <summary>Manages lists of task items supplied by task providers.</summary>
         public Task<IVsTaskList> GetTaskListAsync() => VS.GetServiceAsync<SVsTaskList, IVsTaskList>();

--- a/src/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
+++ b/src/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
@@ -21,6 +21,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\TaskExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\TextBufferExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ContentTypes.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\OutputWindowPane.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\OutputWindowTextWriterVS14.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ProjectTypes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToolkitThreadHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Options\OverrideCollectionNameAttribute.cs" />


### PR DESCRIPTION
`OutputWindowPane` allows an extension to create a new Output window pane or get an existing one.
A pane can be activated (shown), hidden and cleared. Text can be written to the pane via methods like `WriteLineAsync` or with a `TextWriter` returned from `CreateOutputPaneTextWriterAsync`. (For newer versions of VS, this uses [OutputWindowTextWriter](https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.outputwindowtextwriter?view=visualstudiosdk-2019) from the SDK.)

Examples:
```
OutputWindowPane generalPane = await VS.Windows.GetOutputWindowPaneAsync(VSOutputWindowPane.General);
OutputWindowPane buildPane = await VS.Windows.GetOutputWindowPaneAsync(VSOutputWindowPane.Build);
OutputWindowPane debugPane = await VS.Windows.GetOutputWindowPaneAsync(VSOutputWindowPane.Debug);

Guid myPaneGuid;
{
    OutputWindowPane pane = await VS.Windows.CreateOutputWindowPaneAsync("My Pane");
    myPaneGuid = pane.Guid;
    await pane.WriteLineAsync("My message");
}

// Elsewhere:
{
    OutputWindowPane pane = await VS.Windows.GetOutputWindowPaneAsync(myPaneGuid);
    pane.Name = "My Pane - Updated";

    using (TextWriter writer = await pane.CreateOutputPaneTextWriterAsync())
    {
        char[] buffer = GetSomeChars();
        await writer.WriteLineAsync("This is a more efficient way to write lots of text.");
        await writer.WriteAsync(buffer, 0, buffer.Length);
        await writer.WriteLineAsync();
    }
}
```