### PR TITLE
Some improvements to OutputWindowPane

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/ExceptionExtensions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/ExceptionExtensions.cs
@@ -205,22 +205,17 @@ namespace System
             if (_pane == null)
             {
                 // Try and get the Extensions pane and if it doesn't exist then create it.
-                try
+                _pane = await VS.Windows.GetOutputWindowPaneAsync(_extensionsPaneGuid);
+
+                if (_pane == null)
                 {
-                    _pane = await VS.Windows.GetOutputWindowPaneAsync(_extensionsPaneGuid);
-                }
-                finally
-                {
-                    if (_pane == null)
+                    try
                     {
-                        try
-                        {
-                            _pane = await VS.Windows.CreateOutputWindowPaneAsync(_paneTitle);
-                        }
-                        catch (Exception ex)
-                        {
-                            Diagnostics.Debug.WriteLine(ex);
-                        }
+                        _pane = await VS.Windows.CreateOutputWindowPaneAsync(_paneTitle);
+                    }
+                    catch (Exception ex)
+                    {
+                        Diagnostics.Debug.WriteLine(ex);
                     }
                 }
             }

--- a/src/Community.VisualStudio.Toolkit.Shared/Services/Windows.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Services/Windows.cs
@@ -54,20 +54,20 @@ namespace Community.VisualStudio.Toolkit
 
         /// <summary>
         /// Gets an existing Visual Studio Output window pane (General, Build, Debug).
-        /// If the General pane does not already exist then it will be created, but that is not
-        /// the case for Build or Debug.
+        /// If the General pane does not already exist then it will be created, but that is not the case
+        /// for Build or Debug, in which case the method returns null if the pane doesn't already exist.
         /// </summary>
         /// <param name="pane">The Visual Studio pane to get.</param>
-        /// <returns>A new OutputWindowPane.</returns>
-        public Task<OutputWindowPane> GetOutputWindowPaneAsync(VSOutputWindowPane pane) => OutputWindowPane.GetAsync(pane);
+        /// <returns>A new OutputWindowPane or null.</returns>
+        public Task<OutputWindowPane?> GetOutputWindowPaneAsync(VSOutputWindowPane pane) => OutputWindowPane.GetAsync(pane);
 
         /// <summary>
         /// Gets an existing Output window pane.
-        /// Throws if a pane with the specified guid does not exist.
+        /// Returns null if a pane with the specified guid does not exist.
         /// </summary>
         /// <param name="guid">The pane's unique identifier.</param>
-        /// <returns>A new OutputWindowPane.</returns>
-        public Task<OutputWindowPane> GetOutputWindowPaneAsync(Guid guid) => OutputWindowPane.GetAsync(guid);
+        /// <returns>A new OutputWindowPane or null.</returns>
+        public Task<OutputWindowPane?> GetOutputWindowPaneAsync(Guid guid) => OutputWindowPane.GetAsync(guid);
 
         /// <summary>Manages lists of task items supplied by task providers.</summary>
         public Task<IVsTaskList> GetTaskListAsync() => VS.GetServiceAsync<SVsTaskList, IVsTaskList>();


### PR DESCRIPTION
#### 1. Restored the Name getter to query the pane's name if the pane already existed (e.g. when using GetAsync).

Without this change, the following code would return an empty Name:

```
OutputWindowPane pane = await VS.Windows.CreateOutputWindowPaneAsync("My Pane");
myPaneGuid = pane.Guid;

// Elsewhere:
OutputWindowPane myPane = await VS.Windows.GetOutputWindowPaneAsync(myPaneGuid);
Debug.Assert(myPane.Name == "My Pane"); // False! This would be empty
```

#### 2. GetAsync now returns nullable OutputWindowPane to help client usage for checking if a pane exists before creating one.

Previously:

```
async Task GetOrCreateAsync()
{
    try
    {
        await VS.Windows.GetOutputWindowPaneAsync(myPaneGuid);
    }
    finally
    {
        await VS.Windows.CreateOutputWindowPaneAsync("My Pane");
    }
}
```

Now:

```
async Task GetOrCreateAsync()
{
    if (await VS.Windows.GetOutputWindowPaneAsync(myPaneGuid) == null)
    {
        await VS.Windows.CreateOutputWindowPaneAsync("My Pane");
    }
}
```