### PR TITLE
Added the ability to show a 'System.Windows.Window' as a dialog.

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/WindowExtensions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/WindowExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Windows;
+using Microsoft;
+using Microsoft.Internal.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Community.VisualStudio.Toolkit.Shared.ExtensionMethods
+{
+    /// <summary>Extension methods for the <see cref="Window"/> class.</summary>
+    public static class WindowExtensions
+    {
+        /// <summary>Shows a window as a dialog.</summary>
+        public static async Task<bool?> ShowDialogAsync(this Window window, WindowStartupLocation windowStartupLocation = WindowStartupLocation.CenterOwner)
+        {
+            if (window == null)
+                throw new ArgumentNullException(nameof(window));
+
+            var vsUiShellService = await VS.GetServiceAsync<SVsUIShell, IVsUIShell>();
+            Assumes.Present(vsUiShellService);
+
+            if (vsUiShellService.GetDialogOwnerHwnd(out var hwnd) != VSConstants.S_OK)
+                throw new Exception("Unable to get the dialog owner handler.");
+
+            if (vsUiShellService.EnableModeless(0) != VSConstants.S_OK)
+                throw new Exception("Unable to set the UI Shell Service to 'Modeless'.");
+
+            window.WindowStartupLocation = windowStartupLocation;
+
+            try
+            {
+                WindowHelper.ShowModal(window, hwnd);
+                return window.DialogResult;
+            }
+            finally
+            {
+                vsUiShellService.EnableModeless(1);
+            }
+        }
+    }
+}

--- a/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/WindowExtensions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/WindowExtensions.cs
@@ -18,14 +18,13 @@ namespace Community.VisualStudio.Toolkit.Shared.ExtensionMethods
             if (window == null)
                 throw new ArgumentNullException(nameof(window));
 
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
             var vsUiShellService = await VS.GetServiceAsync<SVsUIShell, IVsUIShell>();
             Assumes.Present(vsUiShellService);
 
-            if (vsUiShellService.GetDialogOwnerHwnd(out var hwnd) != VSConstants.S_OK)
-                throw new Exception("Unable to get the dialog owner handler.");
-
-            if (vsUiShellService.EnableModeless(0) != VSConstants.S_OK)
-                throw new Exception("Unable to set the UI Shell Service to 'Modeless'.");
+            ErrorHandler.ThrowOnFailure(vsUiShellService.GetDialogOwnerHwnd(out var hwnd));
+            ErrorHandler.ThrowOnFailure(vsUiShellService.EnableModeless(0));
 
             window.WindowStartupLocation = windowStartupLocation;
 

--- a/src/Community.VisualStudio.Toolkit.Shared/Services/Windows.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Services/Windows.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
+using System.Windows;
+using Community.VisualStudio.Toolkit.Shared.ExtensionMethods;
 using Community.VisualStudio.Toolkit.Shared.Helpers;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
@@ -74,5 +76,9 @@ namespace Community.VisualStudio.Toolkit
 
         /// <summary>Used to manage the Toolbox.</summary>
         public Task<IVsToolbox2> GetToolboxAsync() => VS.GetServiceAsync<SVsToolbox, IVsToolbox2>();
+
+        /// <summary>Shows a window as a dialog.</summary>
+        public async Task<bool?> ShowDialogAsync(Window window, WindowStartupLocation windowStartupLocation = WindowStartupLocation.CenterOwner)
+            => await window.ShowDialogAsync(windowStartupLocation);
     }
 }

--- a/src/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
+++ b/src/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
@@ -21,6 +21,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\SolutionExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\TaskExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\TextBufferExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\WindowExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ContentTypes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\Disposable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\OutputWindowPane.cs" />


### PR DESCRIPTION
Per the [documentation](https://docs.microsoft.com/en-us/visualstudio/extensibility/creating-and-managing-modal-dialog-boxes?view=vs-2019), showing a dialog window properly takes a little more code than just `window.ShowDialog`.  This PR encapsulates that logic in an extension method and also a helper method on the `VS.Windows` class.