### PR TITLE
Added new 'GetRequiredServiceAsync' method.

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/Commands/Commanding.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Commands/Commanding.cs
@@ -11,9 +11,9 @@ namespace Community.VisualStudio.Toolkit
         { }
 
         /// <summary>Provides methods to manage the global designer verbs and menu commands available in design mode, and to show some types of shortcut menus.</summary>
-        public Task<IMenuCommandService> GetCommandServiceAsync() => VS.GetServiceAsync<IMenuCommandService, IMenuCommandService>();
+        public Task<IMenuCommandService> GetCommandServiceAsync() => VS.GetRequiredServiceAsync<IMenuCommandService, IMenuCommandService>();
 
         /// <summary>Used to register and unregister a command target as a high priority command handler.</summary>
-        public Task<IVsRegisterPriorityCommandTarget> GetPriorityCommandTargetAsync() => VS.GetServiceAsync<SVsRegisterPriorityCommandTarget, IVsRegisterPriorityCommandTarget>();
+        public Task<IVsRegisterPriorityCommandTarget> GetPriorityCommandTargetAsync() => VS.GetRequiredServiceAsync<SVsRegisterPriorityCommandTarget, IVsRegisterPriorityCommandTarget>();
     }
 }

--- a/src/Community.VisualStudio.Toolkit.Shared/Editor/Editor.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Editor/Editor.cs
@@ -28,7 +28,7 @@ namespace Community.VisualStudio.Toolkit
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            IComponentModel2 compService = await VS.GetServiceAsync<SComponentModel, IComponentModel2>();
+            IComponentModel2 compService = await VS.GetRequiredServiceAsync<SComponentModel, IComponentModel2>();
             IVsEditorAdaptersFactoryService? editorAdapter = compService.GetService<IVsEditorAdaptersFactoryService>();
             IVsTextView viewAdapter = await GetCurrentNativeTextViewAsync();
 
@@ -38,7 +38,7 @@ namespace Community.VisualStudio.Toolkit
         /// <summary>Gets the native text view from the currently active document.</summary>
         public async Task<IVsTextView> GetCurrentNativeTextViewAsync()
         {
-            IVsTextManager textManager = await VS.GetServiceAsync<SVsTextManager, IVsTextManager>();
+            IVsTextManager textManager = await VS.GetRequiredServiceAsync<SVsTextManager, IVsTextManager>();
             ErrorHandler.ThrowOnFailure(textManager.GetActiveView(1, null, out IVsTextView activeView));
 
             return activeView;

--- a/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/ImageMonikerExtensions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/ImageMonikerExtensions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.Imaging.Interop
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            IVsImageService2 imageService = await VS.GetServiceAsync<SVsImageService, IVsImageService2>();
+            IVsImageService2 imageService = await VS.GetRequiredServiceAsync<SVsImageService, IVsImageService2>();
             Color backColor = VSColorTheme.GetThemedColor(EnvironmentColors.ToolWindowBackgroundColorKey);
 
             var imageAttributes = new ImageAttributes

--- a/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/ProjectExtensions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/ProjectExtensions.cs
@@ -77,7 +77,7 @@ namespace EnvDTE
                 return;
             }
 
-            IVsSolution? solutionService = await VS.GetServiceAsync<SVsSolution, IVsSolution>();
+            IVsSolution? solutionService = await VS.GetRequiredServiceAsync<SVsSolution, IVsSolution>();
             solutionService.GetProjectOfUniqueName(project.UniqueName, out IVsHierarchy? hierarchy);
 
             if (hierarchy == null)

--- a/src/Community.VisualStudio.Toolkit.Shared/Helpers/OutputWindowPane.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Helpers/OutputWindowPane.cs
@@ -277,7 +277,7 @@ namespace Community.VisualStudio.Toolkit.Shared.Helpers
                 // Special case for Visual Studio's General pane
                 if (Guid == VSConstants.OutputWindowPaneGuid.GeneralPane_guid)
                 {
-                    _pane = await VS.GetServiceAsync<SVsGeneralOutputWindowPane, IVsOutputWindowPane>();
+                    _pane = await VS.GetRequiredServiceAsync<SVsGeneralOutputWindowPane, IVsOutputWindowPane>();
                     return;
                 }
 

--- a/src/Community.VisualStudio.Toolkit.Shared/Notifications/Notifications.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Notifications/Notifications.cs
@@ -16,18 +16,18 @@ namespace Community.VisualStudio.Toolkit
 
         /// <summary>The Task Status Center is used to run background tasks and is located in the left-most side of the Status bar.</summary>
         /// <remarks>This is only available for Visual Studio 2019 (16.0).</remarks>
-        public Task<IVsTaskStatusCenterService> GetTaskStatusCenterAsync() => VS.GetServiceAsync<SVsTaskStatusCenterService, IVsTaskStatusCenterService>();
+        public Task<IVsTaskStatusCenterService> GetTaskStatusCenterAsync() => VS.GetRequiredServiceAsync<SVsTaskStatusCenterService, IVsTaskStatusCenterService>();
 #endif
 
         /// <summary>The Infobar is often referred to as the 'yellow' or 'gold' bar.</summary>
         /// <returns>Cast return object to <see cref="IVsInfoBarUIFactory"/></returns>
-        public Task<object> GetInfoBarUIFactoryAsync() => VS.GetServiceAsync<SVsInfoBarUIFactory, object>();
+        public Task<object> GetInfoBarUIFactoryAsync() => VS.GetRequiredServiceAsync<SVsInfoBarUIFactory, object>();
 
         /// <summary>Used for background tasks that needs to block the UI if they take longer than the specified seconds.</summary>
         /// <returns>Cast return object to <see cref="IVsThreadedWaitDialogFactory"/></returns>
-        public Task<object> GetThreadedWaitDialogAsync() => VS.GetServiceAsync<SVsThreadedWaitDialogFactory, object>();
+        public Task<object> GetThreadedWaitDialogAsync() => VS.GetRequiredServiceAsync<SVsThreadedWaitDialogFactory, object>();
 
         /// <summary>Used to write log messaged to the ActivityLog.xml file.</summary>
-        public Task<IVsActivityLog> GetActivityLogAsync() => VS.GetServiceAsync<SVsActivityLog, IVsActivityLog>();
+        public Task<IVsActivityLog> GetActivityLogAsync() => VS.GetRequiredServiceAsync<SVsActivityLog, IVsActivityLog>();
     }
 }

--- a/src/Community.VisualStudio.Toolkit.Shared/Notifications/Statusbar.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Notifications/Statusbar.cs
@@ -12,7 +12,7 @@ namespace Community.VisualStudio.Toolkit
     public partial class Notifications
     {
         /// <summary>Provides access to the environment's status bar.</summary>
-        public Task<IVsStatusbar> GetStatusbarAsync() => VS.GetServiceAsync<SVsStatusbar, IVsStatusbar>();
+        public Task<IVsStatusbar> GetStatusbarAsync() => VS.GetRequiredServiceAsync<SVsStatusbar, IVsStatusbar>();
 
         /// <summary>Gets the current text from the status bar.</summary>
         public async Task<string?> GetStatusbarTextAsync()

--- a/src/Community.VisualStudio.Toolkit.Shared/Options/BaseOptionModel.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Options/BaseOptionModel.cs
@@ -305,7 +305,7 @@ namespace Community.VisualStudio.Toolkit
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             return new ShellSettingsManager(ServiceProvider.GlobalProvider);
 #else
-            IVsSettingsManager? svc = await VS.GetServiceAsync<SVsSettingsManager, IVsSettingsManager>();
+            IVsSettingsManager? svc = await VS.GetRequiredServiceAsync<SVsSettingsManager, IVsSettingsManager>();
 
             return new ShellSettingsManager(svc);
 #endif

--- a/src/Community.VisualStudio.Toolkit.Shared/Services/Debugger.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Services/Debugger.cs
@@ -10,12 +10,12 @@ namespace Community.VisualStudio.Toolkit
         { }
 
         /// <summary>Provides access to the current debugger so that the package can listen for debugger events.</summary>
-        public Task<IVsDebugger> GetDebuggerAsync() => VS.GetServiceAsync<SVsShell, IVsDebugger>();
+        public Task<IVsDebugger> GetDebuggerAsync() => VS.GetRequiredServiceAsync<SVsShell, IVsDebugger>();
 
         /// <summary>Used to launch the debugger.</summary>
-        public Task<IVsDebugLaunch> GetDebugLaunchAsync() => VS.GetServiceAsync<SVsDebugLaunch, IVsDebugLaunch>();
+        public Task<IVsDebugLaunch> GetDebugLaunchAsync() => VS.GetRequiredServiceAsync<SVsDebugLaunch, IVsDebugLaunch>();
 
         /// <summary>Allows clients to add to the debuggable protocol list.`</summary>
-        public Task<IVsDebuggableProtocol> GetDebuggableProtocolAsync() => VS.GetServiceAsync<SVsDebuggableProtocol, IVsDebuggableProtocol>();
+        public Task<IVsDebuggableProtocol> GetDebuggableProtocolAsync() => VS.GetRequiredServiceAsync<SVsDebuggableProtocol, IVsDebuggableProtocol>();
     }
 }

--- a/src/Community.VisualStudio.Toolkit.Shared/Services/Shell.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Services/Shell.cs
@@ -15,33 +15,33 @@ namespace Community.VisualStudio.Toolkit
         { }
 
         /// <summary>Provides access to the fundamental environment services, specifically those dealing with VSPackages and the registry.</summary>
-        public Task<IVsShell> GetShellAsync() => VS.GetServiceAsync<SVsShell, IVsShell>();
+        public Task<IVsShell> GetShellAsync() => VS.GetRequiredServiceAsync<SVsShell, IVsShell>();
 
         /// <summary>This interface provides access to basic windowing functionality, including access to and creation of tool windows and document windows.</summary>
-        public Task<IVsUIShell> GetUIShellAsync() => VS.GetServiceAsync<SVsUIShell, IVsUIShell>();
+        public Task<IVsUIShell> GetUIShellAsync() => VS.GetRequiredServiceAsync<SVsUIShell, IVsUIShell>();
 
         /// <summary>This interface is used by a package to read command-line switches entered by the user.</summary>
-        public Task<IVsAppCommandLine> GetAppCommandLineAsync() => VS.GetServiceAsync<SVsAppCommandLine, IVsAppCommandLine>();
+        public Task<IVsAppCommandLine> GetAppCommandLineAsync() => VS.GetRequiredServiceAsync<SVsAppCommandLine, IVsAppCommandLine>();
 
         /// <summary>Registers well-known images (such as icons) for Visual Studio.</summary>
         /// <returns>Cast return object to <see cref="IVsImageService2"/></returns>
-        public Task<object> GetImageServiceAsync() => VS.GetServiceAsync<SVsImageService, object>();
+        public Task<object> GetImageServiceAsync() => VS.GetRequiredServiceAsync<SVsImageService, object>();
 
         /// <summary>Controls the caching of font and color settings.</summary>
-        public Task<IVsFontAndColorCacheManager> GetFontAndColorCacheManagerAsync() => VS.GetServiceAsync<SVsFontAndColorCacheManager, IVsFontAndColorCacheManager>();
+        public Task<IVsFontAndColorCacheManager> GetFontAndColorCacheManagerAsync() => VS.GetRequiredServiceAsync<SVsFontAndColorCacheManager, IVsFontAndColorCacheManager>();
 
         /// <summary>Allows a VSPackage to retrieve or save font and color data to the registry.</summary>
-        public Task<IVsFontAndColorStorage> GetFontAndColorStorageAsync() => VS.GetServiceAsync<SVsFontAndColorStorage, IVsFontAndColorStorage>();
+        public Task<IVsFontAndColorStorage> GetFontAndColorStorageAsync() => VS.GetRequiredServiceAsync<SVsFontAndColorStorage, IVsFontAndColorStorage>();
 
         /// <summary>Manages a Tools Options dialog box. The environment implements this interface.</summary>
-        public Task<IVsToolsOptions> GetToolsOptionsAsync() => VS.GetServiceAsync<SVsToolsOptions, IVsToolsOptions>();
+        public Task<IVsToolsOptions> GetToolsOptionsAsync() => VS.GetRequiredServiceAsync<SVsToolsOptions, IVsToolsOptions>();
 
         /// <summary>Controls the most recently used (MRU) items collection.</summary>
         /// <returns>Cast return object to <see cref="IVsMRUItemsStore"/></returns>
-        public Task<object> GetMRUItemsStoreAsync() => VS.GetServiceAsync<SVsMRUItemsStore, object>();
+        public Task<object> GetMRUItemsStoreAsync() => VS.GetRequiredServiceAsync<SVsMRUItemsStore, object>();
 
         /// <summary>Used to retrieved services defined in the MEF catalog, such as the editor specific services like <see cref="IVsEditorAdaptersFactoryService"/>.</summary>
-        public Task<IComponentModel2> GetComponentModelAsync() => VS.GetServiceAsync<SComponentModel, IComponentModel2>();
+        public Task<IComponentModel2> GetComponentModelAsync() => VS.GetRequiredServiceAsync<SComponentModel, IComponentModel2>();
 
         /// <summary>
         /// Opens the file via the project instead of as a misc file.
@@ -50,7 +50,7 @@ namespace Community.VisualStudio.Toolkit
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            IVsUIShellOpenDocument openDoc = await VS.GetServiceAsync<SVsUIShellOpenDocument, IVsUIShellOpenDocument>();
+            IVsUIShellOpenDocument openDoc = await VS.GetRequiredServiceAsync<SVsUIShellOpenDocument, IVsUIShellOpenDocument>();
 
             System.Guid viewGuid = VSConstants.LOGVIEWID_TextView;
             if (ErrorHandler.Succeeded(openDoc.OpenDocumentViaProject(fileName, ref viewGuid, out _, out _, out _, out IVsWindowFrame frame)))

--- a/src/Community.VisualStudio.Toolkit.Shared/Services/Solution.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Services/Solution.cs
@@ -21,12 +21,12 @@ namespace Community.VisualStudio.Toolkit
         /// <summary>
         /// Provides top-level manipulation or maintenance of the solution.
         /// </summary>
-        public Task<IVsSolution> GetSolutionAsync() => VS.GetServiceAsync<SVsSolution, IVsSolution>();
+        public Task<IVsSolution> GetSolutionAsync() => VS.GetRequiredServiceAsync<SVsSolution, IVsSolution>();
 
         /// <summary>
         /// Opens a Solution or Project using the standard open dialog boxes.
         /// </summary>
-        public Task<IVsOpenProjectOrSolutionDlg> GetOpenProjectOrSolutionDlgAsync() => VS.GetServiceAsync<SVsOpenProjectOrSolutionDlg, IVsOpenProjectOrSolutionDlg>();
+        public Task<IVsOpenProjectOrSolutionDlg> GetOpenProjectOrSolutionDlgAsync() => VS.GetRequiredServiceAsync<SVsOpenProjectOrSolutionDlg, IVsOpenProjectOrSolutionDlg>();
 
         /// <summary>
         /// Gets a list of the selected items.
@@ -35,7 +35,7 @@ namespace Community.VisualStudio.Toolkit
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            DTE2 dte = await VS.GetServiceAsync<SDTE, DTE2>();
+            DTE2 dte = await VS.GetRequiredServiceAsync<SDTE, DTE2>();
             List<SelectedItem> list = new();
 
             foreach (SelectedItem item in dte.SelectedItems)
@@ -53,7 +53,7 @@ namespace Community.VisualStudio.Toolkit
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            IVsMonitorSelection? monitorSelection = await VS.GetServiceAsync<SVsShellMonitorSelection, IVsMonitorSelection>();
+            IVsMonitorSelection? monitorSelection = await VS.GetRequiredServiceAsync<SVsShellMonitorSelection, IVsMonitorSelection>();
             IntPtr hierarchyPointer = IntPtr.Zero;
             IntPtr selectionContainerPointer = IntPtr.Zero;
             object? selectedObject = null;
@@ -90,7 +90,7 @@ namespace Community.VisualStudio.Toolkit
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            DTE2? dte = await VS.GetServiceAsync<SDTE, DTE2>();
+            DTE2? dte = await VS.GetRequiredServiceAsync<SDTE, DTE2>();
 
             try
             {

--- a/src/Community.VisualStudio.Toolkit.Shared/Services/Windows.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Services/Windows.cs
@@ -26,22 +26,22 @@ namespace Community.VisualStudio.Toolkit
         }
 
         /// <summary>Manipulates the Call Browser for debugging.</summary>
-        public Task<IVsCallBrowser> GetCallBrowserAsync() => VS.GetServiceAsync<SVsCodeWindow, IVsCallBrowser>();
+        public Task<IVsCallBrowser> GetCallBrowserAsync() => VS.GetRequiredServiceAsync<SVsCodeWindow, IVsCallBrowser>();
 
         /// <summary>Allows navigation to an object in Class View.</summary>
-        public Task<IVsClassView> GetClassViewAsync() => VS.GetServiceAsync<SVsClassView, IVsClassView>();
+        public Task<IVsClassView> GetClassViewAsync() => VS.GetRequiredServiceAsync<SVsClassView, IVsClassView>();
 
         /// <summary>Represents a multiple-document interface (MDI) child that contains one or more code views.</summary>
-        public Task<IVsCodeWindow> GetCodeWindowAsync() => VS.GetServiceAsync<SVsCodeWindow, IVsCodeWindow>();
+        public Task<IVsCodeWindow> GetCodeWindowAsync() => VS.GetRequiredServiceAsync<SVsCodeWindow, IVsCodeWindow>();
 
         /// <summary>Enables the package to use the Command Window.</summary>
-        public Task<IVsCommandWindow> GetCommandWindowAsync() => VS.GetServiceAsync<SVsCommandWindow, IVsCommandWindow>();
+        public Task<IVsCommandWindow> GetCommandWindowAsync() => VS.GetRequiredServiceAsync<SVsCommandWindow, IVsCommandWindow>();
 
         /// <summary>Implemented by the environment. Used by VsPackages that want to manipulate Object Browser.</summary>
-        public Task<IVsObjBrowser> GetObjectBrowserAsync() => VS.GetServiceAsync<SVsObjBrowser, IVsObjBrowser>();
+        public Task<IVsObjBrowser> GetObjectBrowserAsync() => VS.GetRequiredServiceAsync<SVsObjBrowser, IVsObjBrowser>();
 
         /// <summary>Manages and controls functions specific to the Output tool window that has multiple panes.</summary>
-        public Task<IVsOutputWindow> GetOutputWindowAsync() => VS.GetServiceAsync<SVsOutputWindow, IVsOutputWindow>();
+        public Task<IVsOutputWindow> GetOutputWindowAsync() => VS.GetRequiredServiceAsync<SVsOutputWindow, IVsOutputWindow>();
 
         /// <summary>
         /// Creates a new Output window pane with the given name.
@@ -70,9 +70,9 @@ namespace Community.VisualStudio.Toolkit
         public Task<OutputWindowPane?> GetOutputWindowPaneAsync(Guid guid) => OutputWindowPane.GetAsync(guid);
 
         /// <summary>Manages lists of task items supplied by task providers.</summary>
-        public Task<IVsTaskList> GetTaskListAsync() => VS.GetServiceAsync<SVsTaskList, IVsTaskList>();
+        public Task<IVsTaskList> GetTaskListAsync() => VS.GetRequiredServiceAsync<SVsTaskList, IVsTaskList>();
 
         /// <summary>Used to manage the Toolbox.</summary>
-        public Task<IVsToolbox2> GetToolboxAsync() => VS.GetServiceAsync<SVsToolbox, IVsToolbox2>();
+        public Task<IVsToolbox2> GetToolboxAsync() => VS.GetRequiredServiceAsync<SVsToolbox, IVsToolbox2>();
     }
 }

--- a/src/Community.VisualStudio.Toolkit.Shared/VS.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/VS.cs
@@ -37,7 +37,7 @@ namespace Community.VisualStudio.Toolkit
         public static Windows Windows => new();
 
         /// <summary>Get the EnvDTE which provide a broad API for a large part of Visual Studio.</summary>
-        public static Task<DTE2> GetDTEAsync() => GetServiceAsync<DTE, DTE2>();
+        public static Task<DTE2> GetDTEAsync() => GetRequiredServiceAsync<DTE, DTE2>();
 
         /// <summary>
         /// Gets a global service asynchronously.

--- a/src/Community.VisualStudio.Toolkit.Shared/VS.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/VS.cs
@@ -45,7 +45,7 @@ namespace Community.VisualStudio.Toolkit
         /// <typeparam name="TService">The type identity of the service.</typeparam>
         /// <typeparam name="TInterface">The interface to cast the service to.</typeparam>
         /// <returns>A task who's result is the service, if found; otherwise <see langword="">null</see>.</returns>
-        public static async Task<TInterface> GetServiceAsync<TService, TInterface>() where TService : class where TInterface : class
+        public static async Task<TInterface?> GetServiceAsync<TService, TInterface>() where TService : class where TInterface : class
         {
 #if VS14
             return (TInterface)await AsyncServiceProvider.GlobalProvider.GetServiceAsync(typeof(TService));

--- a/src/Community.VisualStudio.Toolkit.Shared/VS.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/VS.cs
@@ -48,6 +48,7 @@ namespace Community.VisualStudio.Toolkit
         public static async Task<TInterface?> GetServiceAsync<TService, TInterface>() where TService : class where TInterface : class
         {
 #if VS14
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             return (TInterface)await AsyncServiceProvider.GlobalProvider.GetServiceAsync(typeof(TService));
 #elif VS15
             return await ServiceProvider.GetGlobalServiceAsync<TService, TInterface>();

--- a/src/Community.VisualStudio.Toolkit.Shared/VS.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/VS.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using EnvDTE;
 using EnvDTE80;
 using Microsoft;
@@ -47,13 +48,25 @@ namespace Community.VisualStudio.Toolkit
         public static async Task<TInterface> GetServiceAsync<TService, TInterface>() where TService : class where TInterface : class
         {
 #if VS14
-            var service = (TInterface)await AsyncServiceProvider.GlobalProvider.GetServiceAsync(typeof(TService));
+            return (TInterface)await AsyncServiceProvider.GlobalProvider.GetServiceAsync(typeof(TService));
 #elif VS15
-            TInterface? service = await ServiceProvider.GetGlobalServiceAsync<TService, TInterface>();
+            return await ServiceProvider.GetGlobalServiceAsync<TService, TInterface>();
 #else
-            TInterface? service = await ServiceProvider.GetGlobalServiceAsync<TService, TInterface>(swallowExceptions: false);
+            return await ServiceProvider.GetGlobalServiceAsync<TService, TInterface>(swallowExceptions: false);
 #endif
+        }
+
+        /// <summary>
+        /// Gets a global service asynchronously.
+        /// </summary>
+        /// <typeparam name="TService">The type identity of the service.</typeparam>
+        /// <typeparam name="TInterface">The interface to cast the service to.</typeparam>
+        /// <returns>A task who's result is the service, if found; otherwise throws an exception.</returns>
+        public static async Task<TInterface> GetRequiredServiceAsync<TService, TInterface>() where TService : class where TInterface : class
+        {
+            var service = await GetServiceAsync<TService, TInterface>();
             Assumes.Present(service);
+
             return service;
         }
     }

--- a/src/Community.VisualStudio.Toolkit.Shared/VS.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/VS.cs
@@ -61,7 +61,8 @@ namespace Community.VisualStudio.Toolkit
         /// </summary>
         /// <typeparam name="TService">The type identity of the service.</typeparam>
         /// <typeparam name="TInterface">The interface to cast the service to.</typeparam>
-        /// <returns>A task who's result is the service, if found; otherwise throws an exception.</returns>
+        /// <returns>A task who's result is the service, if found.</returns>
+        /// <exception cref="Exception">Throws an exception when the service is not available.</exception>
         public static async Task<TInterface> GetRequiredServiceAsync<TService, TInterface>() where TService : class where TInterface : class
         {
             var service = await GetServiceAsync<TService, TInterface>();


### PR DESCRIPTION
Based on the XML comments for the `VS.GetServiceAsync` method, it should return `null` if the service is not found... but that's not true. The `Assumes.Present` method will throw an exception if the service is not found. This PR removes that line and creates a new `VS.GetRequiredServiceAsync` method which does perform that logic and follows the current pattern of the `System.IServiceProvider` naming conventions.