### PR TITLE
Fixed foreground and background colors for theming

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/Themes/Themes.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Themes/Themes.cs
@@ -49,8 +49,8 @@ namespace Community.VisualStudio.Toolkit
                 {
                     if ((bool)e.NewValue)
                     {
-                        OverrideProperty(element, Control.BackgroundProperty, _originalBackgroundProperty, EnvironmentColors.StartPageTabBackgroundBrushKey);
-                        OverrideProperty(element, Control.ForegroundProperty, _originalForegroundProperty, EnvironmentColors.StartPageTextBodyBrushKey);
+                        OverrideProperty(element, Control.BackgroundProperty, _originalBackgroundProperty, ThemedDialogColors.WindowPanelBrushKey);
+                        OverrideProperty(element, Control.ForegroundProperty, _originalForegroundProperty, ThemedDialogColors.WindowPanelTextBrushKey);
                         ThemedDialogStyleLoader.SetUseDefaultThemedDialogStyles(element, true);
                         ImageThemingUtilities.SetThemeScrollBars(element, true);
 

--- a/test/VSSDK.TestExtension/ToolWindows/ThemeWindowDemo.xaml
+++ b/test/VSSDK.TestExtension/ToolWindows/ThemeWindowDemo.xaml
@@ -25,6 +25,8 @@
 
             <Label Margin="{StaticResource Margin}">An important label</Label>
 
+            <TextBlock Margin="{StaticResource Margin}">A text block</TextBlock>
+            
             <TextBlock Margin="{StaticResource Margin}">
                 <Hyperlink>Interesting link</Hyperlink>
             </TextBlock>


### PR DESCRIPTION
Fixes #57.

`EnvironmentColors.StartPageTextBodyBrushKey` looked OK when using the dark theme, but it was basically white when using the light and blue themes, so it's not a suitable foreground color.

I've change the foreground color to use `ThemedDialogColors.WindowPanelTextBrushKey`, which appears to be what the `Label` uses:

![image](https://user-images.githubusercontent.com/10321525/121520360-2c95ed80-ca36-11eb-868b-bd94486947a1.png)
(light, blue and dark themes from top to bottom).

To match this change, I've also changed the background color to `ThemedDialogColors.WindowPanelBrushKey`. This _does_ make the background slightly darker for the light and blue themes. The dark theme appears to be the same color.

Before:
![image](https://user-images.githubusercontent.com/10321525/121520533-5c44f580-ca36-11eb-8251-c64dba1e21d0.png)
After:
![image](https://user-images.githubusercontent.com/10321525/121520548-5f3fe600-ca36-11eb-95f1-3b0594dda42b.png)
