### PR TITLE
Change tool window nested Pane classes to internal instead of public

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/ToolWindows/BaseToolWindow.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ToolWindows/BaseToolWindow.cs
@@ -27,7 +27,7 @@ namespace Community.VisualStudio.Toolkit
     ///     }
     ///     
     ///     [Guid("d0050678-2e4f-4a93-adcb-af1370da941d")]
-    ///     public class Pane : ToolWindowPane
+    ///     internal class Pane : ToolWindowPane
     ///     {
     ///         public Pane()
     ///         {

--- a/test/VSSDK.TestExtension/ToolWindows/MultiInstanceWindow.cs
+++ b/test/VSSDK.TestExtension/ToolWindows/MultiInstanceWindow.cs
@@ -22,7 +22,7 @@ namespace TestExtension
         }
 
         [Guid("13dccc25-9d1d-417d-8525-40c4c14ff0a2")]
-        public class Pane : ToolWindowPane
+        internal class Pane : ToolWindowPane
         {
             public Pane()
             {

--- a/test/VSSDK.TestExtension/ToolWindows/RunnerWindow.cs
+++ b/test/VSSDK.TestExtension/ToolWindows/RunnerWindow.cs
@@ -28,7 +28,7 @@ namespace TestExtension
         }
 
         [Guid("d3b3ebd9-87d1-41cd-bf84-268d88953417")]
-        public class Pane : ToolWindowPane
+        internal class Pane : ToolWindowPane
         {
             public Pane()
             {

--- a/test/VSSDK.TestExtension/ToolWindows/ThemeWindow.cs
+++ b/test/VSSDK.TestExtension/ToolWindows/ThemeWindow.cs
@@ -22,7 +22,7 @@ namespace TestExtension
         }
 
         [Guid("e3be6dd3-f017-4d6e-ae88-2b29319a77a2")]
-        public class Pane : ToolWindowPane
+        internal class Pane : ToolWindowPane
         {
             public Pane()
             {


### PR DESCRIPTION
When FxCop/NetAnalyzers are enabled, the nested `public class Pane` causes warning `CA1034: Nested types should not be visible`

This change is mainly for the benefit of people copying these samples, since these analyzers are not enabled in the Toolkit itself.