### PR TITLE
BaseCommand's Command and Package are always non-null

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/Commands/BaseCommand.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Commands/BaseCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel.Design;
 using System.Linq;
 using System.Threading.Tasks;
@@ -29,12 +29,12 @@ namespace Community.VisualStudio.Toolkit
         /// <summary>
         /// The command object associated with the command ID (guid/id).
         /// </summary>
-        public OleMenuCommand? Command { get; private set; }
+        public OleMenuCommand Command { get; private set; } = null!; // This property is initialized in `InitializeAsync`, so it's never actually null.
 
         /// <summary>
         /// The package class that initialized this class.
         /// </summary>
-        public AsyncPackage? Package { get; private set; }
+        public AsyncPackage Package { get; private set; } = null!; // This property is initialized in `InitializeAsync`, so it's never actually null.
 
         /// <summary>
         /// Initializes the command. This method must be called from the <see cref="AsyncPackage.InitializeAsync"/> method for the command to work.
@@ -60,7 +60,7 @@ namespace Community.VisualStudio.Toolkit
             instance.Command.BeforeQueryStatus += (s, e) => { instance.BeforeQueryStatus(e); };
 
             await package.JoinableTaskFactory.SwitchToMainThreadAsync(package.DisposalToken);
-            
+
             var commandService = (IMenuCommandService)await package.GetServiceAsync(typeof(IMenuCommandService));
             Assumes.Present(commandService);
 
@@ -86,7 +86,7 @@ namespace Community.VisualStudio.Toolkit
         /// </remarks>
         protected virtual void Execute(object sender, EventArgs e)
         {
-            Package?.JoinableTaskFactory.RunAsync(async delegate
+            Package.JoinableTaskFactory.RunAsync(async delegate
             {
                 try
                 {
@@ -96,7 +96,7 @@ namespace Community.VisualStudio.Toolkit
                 {
                     await ex.LogAsync();
                 }
-            });
+            }).FireAndForget();
         }
 
         /// <summary>Executes asynchronously when the command is invoked and <c>Execute(object, EventArgs)</c> isn't overridden.</summary>


### PR DESCRIPTION
`BaseCommand.Command` and `BaseCommand.Package` can't be initialized when the object is created, but for all intents and purposes, those two properties are non-null because they are set immediately after the object is created in `BaseCommand.InitializeAsync()`.

For a consumer, needing to use the null-conditional operator for a property that will always be non-null is annoying, so it's best to declare them as non-nullable.

I'm not sure what the preferred way to do this is. I initially wrapped the properties in `#nullable disable`/`#nullable restore`, but decided to instead initialize them to `null!` (using the null-forgiving operator). I'm happy to go with whatever the recommended way is. 😄 