### PR TITLE
Small Improvements

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/Selection/Selection.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Selection/Selection.cs
@@ -100,6 +100,8 @@ namespace Community.VisualStudio.Toolkit
                     VSITEMSELECTION[] items = new VSITEMSELECTION[itemCount];
                     multiSelect.GetSelectedItems(0, itemCount, items);
 
+                    results.Capacity = (int)itemCount;
+
                     foreach (VSITEMSELECTION item in items)
                     {
                         IVsHierarchyItem? hierItem = await item.pHier.ToHierarcyItemAsync(item.itemid);

--- a/src/Community.VisualStudio.Toolkit.Shared/Selection/Selection.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Selection/Selection.cs
@@ -67,7 +67,7 @@ namespace Community.VisualStudio.Toolkit
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            IVsMonitorSelection? svc = await VS.Services.GetMonitorSelectionAsync();
+            IVsMonitorSelection svc = await VS.Services.GetMonitorSelectionAsync();
 
             int cookieResult = svc.GetCmdUIContextCookie(uiContextGuid, out uint cookie);
             ErrorHandler.ThrowOnFailure(cookieResult);
@@ -83,7 +83,7 @@ namespace Community.VisualStudio.Toolkit
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            IVsMonitorSelection? svc = await VS.Services.GetMonitorSelectionAsync();
+            IVsMonitorSelection svc = await VS.Services.GetMonitorSelectionAsync();
             IntPtr hierPtr = IntPtr.Zero;
             IntPtr containerPtr = IntPtr.Zero;
 

--- a/src/Community.VisualStudio.Toolkit.Shared/Solution/File.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Solution/File.cs
@@ -117,10 +117,12 @@ namespace Community.VisualStudio.Toolkit
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             IEnumerable<IVsHierarchy> projects = await VS.Solutions.GetAllProjectHierarchiesAsync();
 
+            VSDOCUMENTPRIORITY[] priority = new VSDOCUMENTPRIORITY[1];
+
             foreach (IVsHierarchy hierarchy in projects)
             {
                 IVsProject proj = (IVsProject)hierarchy;
-                proj.IsDocumentInProject(filePath, out int isFound, new VSDOCUMENTPRIORITY[1], out uint itemId);
+                proj.IsDocumentInProject(filePath, out int isFound, priority, out uint itemId);
 
                 if (isFound == 1)
                 {

--- a/src/Community.VisualStudio.Toolkit.Shared/Solution/File.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Solution/File.cs
@@ -100,7 +100,7 @@ namespace Community.VisualStudio.Toolkit
 
             if (hierarchy is IVsBuildPropertyStorage storage)
             {
-                storage.GetItemAttribute(itemId, name, out string? value);
+                storage.GetItemAttribute(itemId, name, out string value);
                 return value;
             }
 
@@ -115,9 +115,9 @@ namespace Community.VisualStudio.Toolkit
         public static async Task<File?> FromFileAsync(string filePath)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            IEnumerable<IVsHierarchy>? projects = await VS.Solutions.GetAllProjectHierarchiesAsync();
+            IEnumerable<IVsHierarchy> projects = await VS.Solutions.GetAllProjectHierarchiesAsync();
 
-            foreach (IVsHierarchy? hierarchy in projects)
+            foreach (IVsHierarchy hierarchy in projects)
             {
                 IVsProject proj = (IVsProject)hierarchy;
                 proj.IsDocumentInProject(filePath, out int isFound, new VSDOCUMENTPRIORITY[1], out uint itemId);

--- a/src/Community.VisualStudio.Toolkit.Shared/Solution/File.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Solution/File.cs
@@ -54,7 +54,7 @@ namespace Community.VisualStudio.Toolkit
 
             if (parent != null)
             {
-                GetItemInfo(out IVsHierarchy? hierarchy, out uint itemId, out _);
+                GetItemInfo(out IVsHierarchy hierarchy, out uint itemId, out _);
 
                 if (hierarchy is IVsProject2 project)
                 {
@@ -78,7 +78,7 @@ namespace Community.VisualStudio.Toolkit
         public async Task<bool> TrySetAttributeAsync(string name, string value)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            GetItemInfo(out IVsHierarchy? hierarchy, out uint itemId, out _);
+            GetItemInfo(out IVsHierarchy hierarchy, out uint itemId, out _);
 
             if (hierarchy is IVsBuildPropertyStorage storage)
             {
@@ -96,7 +96,7 @@ namespace Community.VisualStudio.Toolkit
         public async Task<string?> GetAttributeAsync(string name)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            GetItemInfo(out IVsHierarchy? hierarchy, out uint itemId, out _);
+            GetItemInfo(out IVsHierarchy hierarchy, out uint itemId, out _);
 
             if (hierarchy is IVsBuildPropertyStorage storage)
             {

--- a/src/Community.VisualStudio.Toolkit.Shared/Solution/Project.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Solution/Project.cs
@@ -56,7 +56,7 @@ namespace Community.VisualStudio.Toolkit
         public async Task<bool> TrySetAttributeAsync(string name, string value)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            GetItemInfo(out IVsHierarchy? hierarchy, out _, out _);
+            GetItemInfo(out IVsHierarchy hierarchy, out _, out _);
 
             if (hierarchy is IVsBuildPropertyStorage storage)
             {
@@ -74,7 +74,7 @@ namespace Community.VisualStudio.Toolkit
         public async Task<string?> GetAttributeAsync(string name)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            GetItemInfo(out IVsHierarchy? hierarchy, out _, out _);
+            GetItemInfo(out IVsHierarchy hierarchy, out _, out _);
 
             if (hierarchy is IVsBuildPropertyStorage storage)
             {

--- a/src/Community.VisualStudio.Toolkit.Shared/Solution/SolutionFolder.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Solution/SolutionFolder.cs
@@ -26,7 +26,7 @@ namespace Community.VisualStudio.Toolkit
             IVsUIShell uiShell = await VS.Services.GetUIShellAsync();
             uiShell.GetDialogOwnerHwnd(out IntPtr hwndDlgOwner);
 
-            GetItemInfo(out IVsHierarchy? hierarchy, out _, out _);
+            GetItemInfo(out IVsHierarchy hierarchy, out _, out _);
 
             Guid rguidEditorType = Guid.Empty, rguidLogicalView = Guid.Empty;
             VSADDRESULT[] result = new VSADDRESULT[1];
@@ -58,7 +58,7 @@ namespace Community.VisualStudio.Toolkit
 
             if (solution != null)
             {
-                GetItemInfo(out IVsHierarchy? hierarchy, out _, out _);
+                GetItemInfo(out IVsHierarchy hierarchy, out _, out _);
 
                 if (hierarchy is IVsSolution ivsSolution)
                 {

--- a/src/Community.VisualStudio.Toolkit.Shared/Solution/SolutionFolder.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Solution/SolutionFolder.cs
@@ -63,7 +63,7 @@ namespace Community.VisualStudio.Toolkit
                 if (hierarchy is IVsSolution ivsSolution)
                 {
                     int hr = ivsSolution.CloseSolutionElement(0, hierarchy, 0);
-                    return hr == 1;
+                    return hr == VSConstants.S_OK;
                 }
             }
 

--- a/src/Community.VisualStudio.Toolkit.Shared/Solution/Solutions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Solution/Solutions.cs
@@ -42,15 +42,12 @@ namespace Community.VisualStudio.Toolkit
         /// </summary>
         public async Task<SolutionItem?> GetActiveSolutionItemAsync()
         {
-            IEnumerable<IVsHierarchyItem>? hierarchies = await VS.Selection.GetSelectedHierarchiesAsync();
-            IVsHierarchyItem? hierarchy = hierarchies.FirstOrDefault();
+            IEnumerable<IVsHierarchyItem> hierarchies = await VS.Selection.GetSelectedHierarchiesAsync();
+            if (!hierarchies.Any())
+                return null;
 
-            if (hierarchy != null)
-            {
-                return await SolutionItem.FromHierarchyAsync(hierarchy.HierarchyIdentity.NestedHierarchy, VSConstants.VSITEMID_ROOT);
-            }
-
-            return null;
+            IVsHierarchyItem hierarchy = hierarchies.First();
+            return await SolutionItem.FromHierarchyAsync(hierarchy.HierarchyIdentity.NestedHierarchy, VSConstants.VSITEMID_ROOT);
         }
 
         /// <summary>
@@ -59,13 +56,15 @@ namespace Community.VisualStudio.Toolkit
         public async Task<Project?> GetActiveProjectAsync()
         {
             SolutionItem? item = await GetActiveSolutionItemAsync();
+            if (item == null)
+                return null;
 
-            if (item?.Type == SolutionItemType.Project)
+            if (item.Type == SolutionItemType.Project)
             {
                 return item as Project;
             }
 
-            return item?.FindParent(SolutionItemType.Project) as Project;
+            return item.FindParent(SolutionItemType.Project) as Project;
         }
 
         /// <summary>
@@ -85,11 +84,11 @@ namespace Community.VisualStudio.Toolkit
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             IVsSolution solution = await VS.Services.GetSolutionAsync();
-            IEnumerable<IVsHierarchy>? hierarchies = solution.GetAllProjectHierarchys();
+            IEnumerable<IVsHierarchy> hierarchies = solution.GetAllProjectHierarchys();
 
             List<Project> list = new();
 
-            foreach (IVsHierarchy? hierarchy in hierarchies)
+            foreach (IVsHierarchy hierarchy in hierarchies)
             {
                 Project? proj = await SolutionItem.FromHierarchyAsync(hierarchy, VSConstants.VSITEMID_ROOT) as Project;
 
@@ -109,7 +108,7 @@ namespace Community.VisualStudio.Toolkit
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             IVsSolution solution = await VS.Services.GetSolutionAsync();
-            return solution?.IsOpen() == true;
+            return solution.IsOpen() == true;
         }
 
         /// <summary>
@@ -119,7 +118,7 @@ namespace Community.VisualStudio.Toolkit
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             IVsSolution solution = await VS.Services.GetSolutionAsync();
-            return solution?.IsOpening() == true;
+            return solution.IsOpening() == true;
         }
     }
 }


### PR DESCRIPTION
- Removed various nullable reference type variable declarations when not needed
- Moved a memory allocation outside of a loop in order to reuse it
- Fixed what I think is a bug in `SolutionFolder.TryRemoveAsync` where it was comparing the HRESULT with a literal 1 instead of `VSConstants.S_OK` (0).