### PR TITLE
Improved CommandExtensions.ExecuteAsync

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/Commands/Commands.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Commands/Commands.cs
@@ -40,13 +40,12 @@ namespace Community.VisualStudio.Toolkit
         public async Task<bool> ExecuteAsync(string name, string argument = "")
         {
             CommandID? cmd = await FindCommandAsync(name);
-
-            if (cmd != null)
+            if (cmd == null)
             {
-                return await ExecuteAsync(cmd.Guid, cmd.ID, argument);
+                return false;
             }
 
-            return false;
+            return await cmd.ExecuteAsync(argument);
         }
 
         /// <summary>

--- a/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/CommandExtensions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/CommandExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading.Tasks;
 using Community.VisualStudio.Toolkit;
 using Microsoft.VisualStudio;
@@ -23,7 +24,8 @@ namespace System.ComponentModel.Design
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             IOleCommandTarget cs = await VS.GetRequiredServiceAsync<SUIHostCommandDispatcher, IOleCommandTarget>();
 
-            IntPtr inArgPtr = Marshal.AllocCoTaskMem(200);
+            int argByteCount = Encoding.Unicode.GetByteCount(argument);
+            IntPtr inArgPtr = Marshal.AllocCoTaskMem(argByteCount);
 
             try
             {


### PR DESCRIPTION
`CommandExtensions.ExecuteAsync` now calculates the required byte size of the input string argument. This was previously hard-coded as 200 bytes.

