### PR TITLE
Add selected solution item to GetSelectedItemsAsync()

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/IVsHierarchyExtensions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/IVsHierarchyExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
         /// Converts a <see cref="IVsHierarchy"/> to a <see cref="IVsHierarchyItem"/>.
         /// </summary>
         /// <returns>Returns <see langword="null"/> if unable to get the hierarchy item.</returns>
-        public static async Task<IVsHierarchyItem?> ToHierarcyItemAsync(this IVsHierarchy hierarchy, uint itemId)
+        public static async Task<IVsHierarchyItem?> ToHierarchyItemAsync(this IVsHierarchy hierarchy, uint itemId)
         {
             if (hierarchy == null)
             {
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
         /// Converts a <see cref="IVsHierarchy"/> to a <see cref="IVsHierarchyItem"/>.
         /// </summary>
         /// <returns>Returns <see langword="null"/> if unable to get the hierarchy item.</returns>
-        public static IVsHierarchyItem? ToHierarcyItem(this IVsHierarchy hierarchy, uint itemId)
+        public static IVsHierarchyItem? ToHierarchyItem(this IVsHierarchy hierarchy, uint itemId)
         {
             if (hierarchy == null)
             {

--- a/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/IVsSolutionExtensions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/IVsSolutionExtensions.cs
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
             
             if (solution is IVsHierarchy hier)
             {
-                IVsHierarchyItem? item = await hier.ToHierarcyItemAsync(VSConstants.VSITEMID_ROOT);
+                IVsHierarchyItem? item = await hier.ToHierarchyItemAsync(VSConstants.VSITEMID_ROOT);
                 return SolutionItem.FromHierarchyItem(item);
             }
 

--- a/src/Community.VisualStudio.Toolkit.Shared/Notifications/MessageBox.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Notifications/MessageBox.cs
@@ -11,7 +11,7 @@ namespace Community.VisualStudio.Toolkit
     public class MessageBox
     {
         /// <summary>
-        /// Shows a message box that is parented to the main Visual Studio window
+        /// Shows a message box that is parented to the main Visual Studio window.
         /// </summary>
         /// <returns>
         /// The result of which button on the message box was clicked.
@@ -22,10 +22,10 @@ namespace Community.VisualStudio.Toolkit
         /// </code>
         /// </example>
         public MessageBoxResult Show(string line1,
-                                            string line2 = "",
-                                            OLEMSGICON icon = OLEMSGICON.OLEMSGICON_INFO,
-                                            OLEMSGBUTTON buttons = OLEMSGBUTTON.OLEMSGBUTTON_OKCANCEL,
-                                            OLEMSGDEFBUTTON defaultButton = OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST)
+            string line2 = "",
+            OLEMSGICON icon = OLEMSGICON.OLEMSGICON_INFO,
+            OLEMSGBUTTON buttons = OLEMSGBUTTON.OLEMSGBUTTON_OKCANCEL,
+            OLEMSGDEFBUTTON defaultButton = OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
             int result = VsShellUtilities.ShowMessageBox(ServiceProvider.GlobalProvider, line2, line1, icon, buttons, defaultButton);
@@ -34,7 +34,7 @@ namespace Community.VisualStudio.Toolkit
         }
 
         /// <summary>
-        /// Shows a message box that is parented to the main Visual Studio window
+        /// Shows a message box that is parented to the main Visual Studio window.
         /// </summary>
         /// <returns>
         /// The result of which button on the message box was clicked.
@@ -45,13 +45,13 @@ namespace Community.VisualStudio.Toolkit
         /// </code>
         /// </example>
         public async Task<MessageBoxResult> ShowAsync(string line1,
-                                    string line2 = "",
-                                    OLEMSGICON icon = OLEMSGICON.OLEMSGICON_INFO,
-                                    OLEMSGBUTTON buttons = OLEMSGBUTTON.OLEMSGBUTTON_OKCANCEL,
-                                    OLEMSGDEFBUTTON defaultButton = OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST)
+            string line2 = "",
+            OLEMSGICON icon = OLEMSGICON.OLEMSGICON_INFO,
+            OLEMSGBUTTON buttons = OLEMSGBUTTON.OLEMSGBUTTON_OKCANCEL,
+            OLEMSGDEFBUTTON defaultButton = OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            return Show(line2, line1, icon, buttons, defaultButton);
+            return Show(line1, line2, icon, buttons, defaultButton);
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace Community.VisualStudio.Toolkit
         }
 
         /// <summary>
-        /// Shows a yes/no/cancel message box .
+        /// Shows a yes/no/cancel message box.
         /// </summary>
         /// <returns>true if the user clicks the 'Yes' button.</returns>
         public bool ShowConfirm(string line1, string line2 = "")
@@ -105,7 +105,7 @@ namespace Community.VisualStudio.Toolkit
         }
 
         /// <summary>
-        /// Shows a yes/no/cancel message box .
+        /// Shows a yes/no/cancel message box.
         /// </summary>
         /// <returns>true if the user clicks the 'Yes' button.</returns>
         public async Task<bool> ShowConfirmAsync(string line1, string line2 = "")

--- a/src/Community.VisualStudio.Toolkit.Shared/Selection/Selection.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Selection/Selection.cs
@@ -105,11 +105,26 @@ namespace Community.VisualStudio.Toolkit
                     foreach (VSITEMSELECTION item in items)
                     {
                         IVsHierarchyItem? hierItem = await item.pHier.ToHierarcyItemAsync(item.itemid);
-                        if (hierItem != null && !results.Contains(hierItem))
+
+                        if (hierItem != null)
                         {
                             results.Add(hierItem);
                         }
+                        else
+                        {
+                            IVsHierarchy solution = (IVsHierarchy)await VS.Services.GetSolutionAsync();
+                            IVsHierarchyItem? sol = await solution.ToHierarcyItemAsync(VSConstants.VSITEMID_ROOT);
+
+                            if (sol != null)
+                            {
+                                results.Add(sol);
+                            }
+                        }
                     }
+                }
+                else if (itemId == VSConstants.VSITEMID_NIL)
+                {
+                    // Empty Solution Explorer or nothing selected, so don't add anything.
                 }
                 else if (hierPtr != IntPtr.Zero)
                 {
@@ -124,6 +139,7 @@ namespace Community.VisualStudio.Toolkit
                 else if (await VS.Services.GetSolutionAsync() is IVsHierarchy solution)
                 {
                     IVsHierarchyItem? sol = await solution.ToHierarcyItemAsync(VSConstants.VSITEMID_ROOT);
+
                     if (sol != null)
                     {
                         results.Add(sol);
@@ -147,7 +163,7 @@ namespace Community.VisualStudio.Toolkit
                 }
             }
 
-            return results;
+            return results.Distinct();
         }
     }
 }

--- a/src/Community.VisualStudio.Toolkit.Shared/Selection/Selection.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Selection/Selection.cs
@@ -104,7 +104,7 @@ namespace Community.VisualStudio.Toolkit
 
                     foreach (VSITEMSELECTION item in items)
                     {
-                        IVsHierarchyItem? hierItem = await item.pHier.ToHierarcyItemAsync(item.itemid);
+                        IVsHierarchyItem? hierItem = await item.pHier.ToHierarchyItemAsync(item.itemid);
 
                         if (hierItem != null)
                         {
@@ -113,7 +113,7 @@ namespace Community.VisualStudio.Toolkit
                         else
                         {
                             IVsHierarchy solution = (IVsHierarchy)await VS.Services.GetSolutionAsync();
-                            IVsHierarchyItem? sol = await solution.ToHierarcyItemAsync(VSConstants.VSITEMID_ROOT);
+                            IVsHierarchyItem? sol = await solution.ToHierarchyItemAsync(VSConstants.VSITEMID_ROOT);
 
                             if (sol != null)
                             {
@@ -129,7 +129,7 @@ namespace Community.VisualStudio.Toolkit
                 else if (hierPtr != IntPtr.Zero)
                 {
                     IVsHierarchy hierarchy = (IVsHierarchy)Marshal.GetUniqueObjectForIUnknown(hierPtr);
-                    IVsHierarchyItem? hierItem = await hierarchy.ToHierarcyItemAsync(itemId);
+                    IVsHierarchyItem? hierItem = await hierarchy.ToHierarchyItemAsync(itemId);
 
                     if (hierItem != null)
                     {
@@ -138,7 +138,7 @@ namespace Community.VisualStudio.Toolkit
                 }
                 else if (await VS.Services.GetSolutionAsync() is IVsHierarchy solution)
                 {
-                    IVsHierarchyItem? sol = await solution.ToHierarcyItemAsync(VSConstants.VSITEMID_ROOT);
+                    IVsHierarchyItem? sol = await solution.ToHierarchyItemAsync(VSConstants.VSITEMID_ROOT);
 
                     if (sol != null)
                     {

--- a/src/Community.VisualStudio.Toolkit.Shared/Solution/SolutionItem.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Solution/SolutionItem.cs
@@ -98,7 +98,7 @@ namespace Community.VisualStudio.Toolkit
         public static async Task<SolutionItem?> FromHierarchyAsync(IVsHierarchy hierarchy, uint itemId)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            IVsHierarchyItem? item = await hierarchy.ToHierarcyItemAsync(itemId);
+            IVsHierarchyItem? item = await hierarchy.ToHierarchyItemAsync(itemId);
 
             return FromHierarchyItem(item);
         }
@@ -109,7 +109,7 @@ namespace Community.VisualStudio.Toolkit
         public static SolutionItem? FromHierarchy(IVsHierarchy hierarchy, uint itemId)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            IVsHierarchyItem? item = hierarchy.ToHierarcyItem(itemId);
+            IVsHierarchyItem? item = hierarchy.ToHierarchyItem(itemId);
 
             return FromHierarchyItem(item);
         }

--- a/src/Community.VisualStudio.Toolkit.Shared/Solution/Solutions.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Solution/Solutions.cs
@@ -22,7 +22,7 @@ namespace Community.VisualStudio.Toolkit
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             IVsHierarchy solution = (IVsHierarchy)await VS.Services.GetSolutionAsync();
-            IVsHierarchyItem? hierItem = await solution.ToHierarcyItemAsync(VSConstants.VSITEMID_ROOT);
+            IVsHierarchyItem? hierItem = await solution.ToHierarchyItemAsync(VSConstants.VSITEMID_ROOT);
             return SolutionItem.FromHierarchyItem(hierItem);
         }
 
@@ -33,7 +33,7 @@ namespace Community.VisualStudio.Toolkit
         {
             ThreadHelper.ThrowIfNotOnUIThread();
             IVsHierarchy solution = VS.GetRequiredService<SVsSolution, IVsHierarchy>();
-            IVsHierarchyItem? hierItem = solution.ToHierarcyItem(VSConstants.VSITEMID_ROOT);
+            IVsHierarchyItem? hierItem = solution.ToHierarchyItem(VSConstants.VSITEMID_ROOT);
             return SolutionItem.FromHierarchyItem(hierItem);
         }
 


### PR DESCRIPTION
This fixes #107 (for the most part).  There are some other scenarios I noticed, but can be done in a future issue/PR.  For example, selecting multiple items under a project's Analyzers don't appear to return correctly.

This also updated some misspellings and found line variables swapped when showing a message box.