### PR TITLE
Remove results.Distinct()

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/Selection/Selection.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Selection/Selection.cs
@@ -163,7 +163,7 @@ namespace Community.VisualStudio.Toolkit
                 }
             }
 
-            return results.Distinct();
+            return results;
         }
     }
 }


### PR DESCRIPTION
Closes #109 

I believe @shaggygi's refactoring to use `results.Distinct` was to keep the previous logic of

```
if (hierItem != null && !results.Contains(hierItem))
```

But based on the discussion in #109 I don't think this is needed.