### PR TITLE
*** POC *** Add Dependency Injection to the ToolkitPackage

### DIFF
--- a/src/AssemblyInfo.cs
+++ b/src/AssemblyInfo.cs
@@ -3,3 +3,5 @@
 using Microsoft.VisualStudio.Shell;
 
 [assembly: ProvideCodeBase(AssemblyName = "Community.VisualStudio.Toolkit")]
+[assembly: ProvideCodeBase(AssemblyName = "Microsoft.Extensions.DependencyInjection")]
+[assembly: ProvideCodeBase(AssemblyName = "Microsoft.Extensions.DependencyInjection.Abstractions")]

--- a/src/Community.VisualStudio.Toolkit.14.0/Community.VisualStudio.Toolkit.14.0.csproj
+++ b/src/Community.VisualStudio.Toolkit.14.0/Community.VisualStudio.Toolkit.14.0.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Madskristensen.VisualStudio.SDK" Version="14.0.83" IncludeAssets="All" PrivateAssets="None" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime" Version="12.1.30329" />
   </ItemGroup>

--- a/src/Community.VisualStudio.Toolkit.15.0/Community.VisualStudio.Toolkit.15.0.csproj
+++ b/src/Community.VisualStudio.Toolkit.15.0/Community.VisualStudio.Toolkit.15.0.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\Common.props"/>
+  <Import Project="..\Common.props" />
   
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="15.0.*" IncludeAssets="All" PrivateAssets="None" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Community.VisualStudio.Toolkit.16.0/Community.VisualStudio.Toolkit.16.0.csproj
+++ b/src/Community.VisualStudio.Toolkit.16.0/Community.VisualStudio.Toolkit.16.0.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.*" IncludeAssets="All" PrivateAssets="None" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime" Version="12.1.30329" />

--- a/src/Community.VisualStudio.Toolkit.16.0/Community.VisualStudio.Toolkit.16.0.csproj
+++ b/src/Community.VisualStudio.Toolkit.16.0/Community.VisualStudio.Toolkit.16.0.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.*" IncludeAssets="All" PrivateAssets="None" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime" Version="12.1.30329" />

--- a/src/Community.VisualStudio.Toolkit.17.0/Community.VisualStudio.Toolkit.17.0.csproj
+++ b/src/Community.VisualStudio.Toolkit.17.0/Community.VisualStudio.Toolkit.17.0.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-1-31410-273" IncludeAssets="All" PrivateAssets="None" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Community.VisualStudio.Toolkit.17.0/Community.VisualStudio.Toolkit.17.0.csproj
+++ b/src/Community.VisualStudio.Toolkit.17.0/Community.VisualStudio.Toolkit.17.0.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-1-31410-273" IncludeAssets="All" PrivateAssets="None" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Community.VisualStudio.Toolkit.Shared/DependencyInjection/IToolkitServiceProvider.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/DependencyInjection/IToolkitServiceProvider.cs
@@ -6,7 +6,9 @@ namespace Community.VisualStudio.Toolkit.Shared.DependencyInjection
     /// <summary>
     /// Service provider
     /// </summary>
-    public interface IToolkitServiceProvider: IServiceProvider
+    /// <typeparam name="TPackage">Type of the implementing package.</typeparam>
+    public interface IToolkitServiceProvider<TPackage> : IServiceProvider
+         where TPackage : AsyncPackage
     {
     }
 }

--- a/src/Community.VisualStudio.Toolkit.Shared/DependencyInjection/IToolkitServiceProvider.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/DependencyInjection/IToolkitServiceProvider.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using Microsoft.VisualStudio.Shell;
+
+namespace Community.VisualStudio.Toolkit.Shared.DependencyInjection
+{
+    /// <summary>
+    /// Service provider
+    /// </summary>
+    public interface IToolkitServiceProvider: IServiceProvider
+    {
+    }
+}

--- a/src/Community.VisualStudio.Toolkit.Shared/DependencyInjection/SToolkitServiceProvider.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/DependencyInjection/SToolkitServiceProvider.cs
@@ -1,0 +1,9 @@
+﻿namespace Community.VisualStudio.Toolkit.Shared.DependencyInjection
+{
+    /// <summary>
+    /// Placeholder interface for registering the <see cref="IToolkitServiceProvider"/> in the main Visual Studio service provider.
+    /// </summary>
+    interface SToolkitServiceProvider
+    {
+    }
+}

--- a/src/Community.VisualStudio.Toolkit.Shared/DependencyInjection/SToolkitServiceProvider.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/DependencyInjection/SToolkitServiceProvider.cs
@@ -1,9 +1,10 @@
 ﻿namespace Community.VisualStudio.Toolkit.Shared.DependencyInjection
 {
     /// <summary>
-    /// Placeholder interface for registering the <see cref="IToolkitServiceProvider"/> in the main Visual Studio service provider.
+    /// Placeholder interface for registering the <see cref="IToolkitServiceProvider{TPackage}"/> in the main Visual Studio service provider.
     /// </summary>
-    public interface SToolkitServiceProvider
+    /// <typeparam name="TPackage">Type of the implementing package.</typeparam>
+    public interface SToolkitServiceProvider<TPackage>
     {
     }
 }

--- a/src/Community.VisualStudio.Toolkit.Shared/DependencyInjection/SToolkitServiceProvider.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/DependencyInjection/SToolkitServiceProvider.cs
@@ -1,10 +1,13 @@
-﻿namespace Community.VisualStudio.Toolkit.Shared.DependencyInjection
+﻿using Microsoft.VisualStudio.Shell;
+
+namespace Community.VisualStudio.Toolkit.Shared.DependencyInjection
 {
     /// <summary>
     /// Placeholder interface for registering the <see cref="IToolkitServiceProvider{TPackage}"/> in the main Visual Studio service provider.
     /// </summary>
     /// <typeparam name="TPackage">Type of the implementing package.</typeparam>
     public interface SToolkitServiceProvider<TPackage>
+        where TPackage : AsyncPackage
     {
     }
 }

--- a/src/Community.VisualStudio.Toolkit.Shared/DependencyInjection/SToolkitServiceProvider.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/DependencyInjection/SToolkitServiceProvider.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Placeholder interface for registering the <see cref="IToolkitServiceProvider"/> in the main Visual Studio service provider.
     /// </summary>
-    interface SToolkitServiceProvider
+    public interface SToolkitServiceProvider
     {
     }
 }

--- a/src/Community.VisualStudio.Toolkit.Shared/DependencyInjection/ToolkitServiceProvider.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/DependencyInjection/ToolkitServiceProvider.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Community.VisualStudio.Toolkit.Shared.DependencyInjection
+{
+    internal class ToolkitServiceProvider : IToolkitServiceProvider
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public ToolkitServiceProvider(ServiceCollection services)
+        {
+            _serviceProvider = services.BuildServiceProvider();
+        }
+
+        public object GetService(Type serviceType)
+        {
+            return _serviceProvider.GetService(serviceType);
+        }
+    }
+}

--- a/src/Community.VisualStudio.Toolkit.Shared/DependencyInjection/ToolkitServiceProvider.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/DependencyInjection/ToolkitServiceProvider.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.Shell;
 
 namespace Community.VisualStudio.Toolkit.Shared.DependencyInjection
 {
-    internal class ToolkitServiceProvider : IToolkitServiceProvider
+    internal class ToolkitServiceProvider<TPackage> : IToolkitServiceProvider<TPackage>
+         where TPackage : AsyncPackage
     {
         private readonly IServiceProvider _serviceProvider;
 

--- a/src/Community.VisualStudio.Toolkit.Shared/DependencyInjectionContainerToolkitPackage.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/DependencyInjectionContainerToolkitPackage.cs
@@ -1,0 +1,55 @@
+﻿using System.Threading;
+using System;
+using Community.VisualStudio.Toolkit.Shared.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+namespace Community.VisualStudio.Toolkit
+{
+    /// <summary>
+    /// Package that contains a DI service container.
+    /// </summary>
+    /// <typeparam name="TPackage"></typeparam>
+    [ProvideService(typeof(SToolkitServiceProvider<>), IsAsyncQueryable = true)]
+    public class DependencyInjectionContainerToolkitPackage<TPackage> : ToolkitPackage
+        where TPackage : AsyncPackage
+    {
+        /// <summary>
+        /// Custom ServiceProvider for the package.
+        /// </summary>
+        public IToolkitServiceProvider<TPackage> ServiceProvider { get; private set; } = null!; // This property is initialized in `InitializeAsync`, so it's never actually null.
+
+        /// <summary>
+        /// Initializes the <see cref="AsyncPackage"/>
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <param name="progress"></param>
+        /// <returns></returns>
+        protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+        {
+            await base.InitializeAsync(cancellationToken, progress);
+
+            ServiceCollection services = new ServiceCollection();
+            InitializeServices(services);
+            ServiceProvider = new ToolkitServiceProvider<TPackage>(services);
+
+            // Add the IToolkitServiceProvider to the VS IServiceProvider
+            AsyncServiceCreatorCallback serviceCreatorCallback = (sc, ct, t) =>
+            {
+                return Task.FromResult((object)this.ServiceProvider);
+            };
+
+            AddService(typeof(SToolkitServiceProvider<TPackage>), serviceCreatorCallback, true);
+        }
+
+        /// <summary>
+        /// Initialize the services in the DI container.
+        /// </summary>
+        /// <param name="services"></param>
+        protected virtual void InitializeServices(ServiceCollection services)
+        {
+            // Nothing
+        }
+    }
+}

--- a/src/Community.VisualStudio.Toolkit.Shared/ToolkitPackage.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ToolkitPackage.cs
@@ -45,7 +45,7 @@ namespace Community.VisualStudio.Toolkit
                 return Task.FromResult((object)this.ServiceProvider);
             };
 
-            AddService(typeof(SToolkitServiceProvider), serviceCreatorCallback, false);
+            AddService(typeof(SToolkitServiceProvider), serviceCreatorCallback, true);
         }
 
         /// <summary>

--- a/src/Community.VisualStudio.Toolkit.Shared/ToolkitPackage.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/ToolkitPackage.cs
@@ -4,58 +4,17 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
-using Community.VisualStudio.Toolkit.Shared.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using Task = System.Threading.Tasks.Task;
 
 namespace Community.VisualStudio.Toolkit
 {
     /// <summary>
     /// An <see cref="AsyncPackage"/> that provides additional functionality.
     /// </summary>
-    [ProvideService(typeof(SToolkitServiceProvider), IsAsyncQueryable = true)]
     public abstract class ToolkitPackage : AsyncPackage
     {
         private List<IToolWindowProvider>? _toolWindowProviders;
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public IToolkitServiceProvider ServiceProvider { get; private set; } = null!; // This property is initialized in `InitializeAsync`, so it's never actually null.
-
-        /// <summary>
-        /// Initializes the <see cref="AsyncPackage"/>
-        /// </summary>
-        /// <param name="cancellationToken"></param>
-        /// <param name="progress"></param>
-        /// <returns></returns>
-        protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
-        {
-            await base.InitializeAsync(cancellationToken, progress);
-
-            ServiceCollection services = new ServiceCollection();
-            InitializeServices(services);
-            ServiceProvider = new ToolkitServiceProvider(services);
-
-            // Add the IToolkitServiceProvider to the VS IServiceProvider
-            AsyncServiceCreatorCallback serviceCreatorCallback = (sc, ct, t) =>
-            {
-                return Task.FromResult((object)this.ServiceProvider);
-            };
-
-            AddService(typeof(SToolkitServiceProvider), serviceCreatorCallback, true);
-        }
-
-        /// <summary>
-        /// Initialize the services in the DI container.
-        /// </summary>
-        /// <param name="services"></param>
-        protected virtual void InitializeServices(ServiceCollection services)
-        {
-            // Nothing
-        }
 
         internal void AddToolWindow(IToolWindowProvider provider)
         {

--- a/src/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
+++ b/src/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Build\Build.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Commands\CommandAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Commands\KnownCommands.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DependencyInjectionContainerToolkitPackage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DependencyInjection\IToolkitServiceProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DependencyInjection\SToolkitServiceProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DependencyInjection\ToolkitServiceProvider.cs" />

--- a/src/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
+++ b/src/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
@@ -12,6 +12,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Build\Build.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Commands\CommandAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Commands\KnownCommands.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DependencyInjection\IToolkitServiceProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DependencyInjection\SToolkitServiceProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DependencyInjection\ToolkitServiceProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Documents\Documents.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Documents\DocumentView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\IVsTextViewExtensions.cs" />

--- a/test/VSSDK.TestExtension/Commands/DependencyInjectionCommand.cs
+++ b/test/VSSDK.TestExtension/Commands/DependencyInjectionCommand.cs
@@ -2,6 +2,7 @@
 using Community.VisualStudio.Toolkit;
 using Community.VisualStudio.Toolkit.Shared.DependencyInjection;
 using Microsoft.VisualStudio.Shell;
+using VSSDK.TestExtension;
 
 namespace TestExtension.Commands
 {
@@ -12,9 +13,9 @@ namespace TestExtension.Commands
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            IToolkitServiceProvider serviceProvider = await VS.GetRequiredServiceAsync<SToolkitServiceProvider, IToolkitServiceProvider>();
+            IToolkitServiceProvider<TestExtensionPackage> serviceProvider = await VS.GetRequiredServiceAsync<SToolkitServiceProvider<TestExtensionPackage>, IToolkitServiceProvider<TestExtensionPackage>>();
 
-            await VS.MessageBox.ShowAsync($"The {nameof(IToolkitServiceProvider)} was retrieved from the service collection succuessfully!");
+            await VS.MessageBox.ShowAsync($"The {nameof(IToolkitServiceProvider<TestExtensionPackage>)} was retrieved from the service collection succuessfully!");
         }
     }
 }

--- a/test/VSSDK.TestExtension/Commands/DependencyInjectionCommand.cs
+++ b/test/VSSDK.TestExtension/Commands/DependencyInjectionCommand.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+using Community.VisualStudio.Toolkit;
+using Community.VisualStudio.Toolkit.Shared.DependencyInjection;
+using Microsoft.VisualStudio.Shell;
+
+namespace TestExtension.Commands
+{
+    [Command(PackageIds.TestDependencyInjection)]
+    internal sealed class DependencyInjectionCommand : BaseCommand<DependencyInjectionCommand>
+    {
+        protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            IToolkitServiceProvider serviceProvider = await VS.GetRequiredServiceAsync<SToolkitServiceProvider, IToolkitServiceProvider>();
+
+            await VS.MessageBox.ShowAsync($"The {nameof(IToolkitServiceProvider)} was retrieved from the service collection succuessfully!");
+        }
+    }
+}

--- a/test/VSSDK.TestExtension/Properties/AssemblyInfo.cs
+++ b/test/VSSDK.TestExtension/Properties/AssemblyInfo.cs
@@ -1,3 +1,5 @@
 ﻿using Microsoft.VisualStudio.Shell;
 
 [assembly: ProvideCodeBase(AssemblyName = "Community.VisualStudio.Toolkit")]
+[assembly: ProvideCodeBase(AssemblyName = "Microsoft.Extensions.DependencyInjection", CodeBase = "$PackageFolder$\\Microsoft.Extensions.DependencyInjection.dll")]
+[assembly: ProvideCodeBase(AssemblyName = "Microsoft.Extensions.DependencyInjection.Abstractions", CodeBase = "$PackageFolder$\\Microsoft.Extensions.DependencyInjection.Abstractions.dll")]

--- a/test/VSSDK.TestExtension/TestExtensionPackage.cs
+++ b/test/VSSDK.TestExtension/TestExtensionPackage.cs
@@ -8,9 +8,6 @@ using TestExtension;
 using TestExtension.Commands;
 using Task = System.Threading.Tasks.Task;
 
-[assembly: ProvideCodeBase(AssemblyName = "Microsoft.Extensions.DependencyInjection", CodeBase = "$PackageFolder$\\Microsoft.Extensions.DependencyInjection.dll")]
-[assembly: ProvideCodeBase(AssemblyName = "Microsoft.Extensions.DependencyInjection.Abstractions", CodeBase = "$PackageFolder$\\Microsoft.Extensions.DependencyInjection.Abstractions.dll")]
-
 namespace VSSDK.TestExtension
 {
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]

--- a/test/VSSDK.TestExtension/TestExtensionPackage.cs
+++ b/test/VSSDK.TestExtension/TestExtensionPackage.cs
@@ -23,7 +23,7 @@ namespace VSSDK.TestExtension
     [ProvideFileIcon(".abc", "KnownMonikers.Reference")]
     [ProvideToolWindow(typeof(MultiInstanceWindow.Pane))]
     [ProvideMenuResource("Menus.ctmenu", 1)]
-    public sealed class TestExtensionPackage : ToolkitPackage
+    public sealed class TestExtensionPackage : DependencyInjectionContainerToolkitPackage<TestExtensionPackage>
     {
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {

--- a/test/VSSDK.TestExtension/TestExtensionPackage.cs
+++ b/test/VSSDK.TestExtension/TestExtensionPackage.cs
@@ -8,6 +8,9 @@ using TestExtension;
 using TestExtension.Commands;
 using Task = System.Threading.Tasks.Task;
 
+[assembly: ProvideCodeBase(AssemblyName = "Microsoft.Extensions.DependencyInjection", CodeBase = "$PackageFolder$\\Microsoft.Extensions.DependencyInjection.dll")]
+[assembly: ProvideCodeBase(AssemblyName = "Microsoft.Extensions.DependencyInjection.Abstractions", CodeBase = "$PackageFolder$\\Microsoft.Extensions.DependencyInjection.Abstractions.dll")]
+
 namespace VSSDK.TestExtension
 {
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
@@ -24,6 +27,8 @@ namespace VSSDK.TestExtension
     {
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
+            await base.InitializeAsync(cancellationToken, progress);
+
             // Tool windows
             RunnerWindow.Initialize(this);
             ThemeWindow.Initialize(this);
@@ -37,6 +42,7 @@ namespace VSSDK.TestExtension
             await MultiInstanceWindowCommand.InitializeAsync(this);
             await BuildActiveProjectAsyncCommand.InitializeAsync(this);
             await BuildSolutionAsyncCommand.InitializeAsync(this);
+            await DependencyInjectionCommand.InitializeAsync(this);
         }
     }
 }

--- a/test/VSSDK.TestExtension/VSCommandTable.cs
+++ b/test/VSSDK.TestExtension/VSCommandTable.cs
@@ -27,5 +27,6 @@ namespace TestExtension
         public const int MultiInstanceWindow = 0x0102;
         public const int BuildActiveProjectAsync = 0x0103;
         public const int BuildSolutionAsync = 0x0104;
+        public const int TestDependencyInjection = 0x0105;
     }
 }

--- a/test/VSSDK.TestExtension/VSCommandTable.vsct
+++ b/test/VSSDK.TestExtension/VSCommandTable.vsct
@@ -70,6 +70,15 @@
           <ButtonText>Build Solution Async</ButtonText>
         </Strings>
       </Button>
+
+      <Button guid="TestExtension" id="TestDependencyInjection" priority="0x0102" type="Button">
+        <Parent guid="TestExtension" id="TestExtensionMainMenuGroup1"/>
+        <Icon guid="ImageCatalogGuid" id="BuildSolution" />
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <Strings>
+          <ButtonText>Test Dependency Injection Functionality</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
   </Commands>
 
@@ -83,6 +92,7 @@
       <IDSymbol name="MultiInstanceWindow" value="0x0102" />
       <IDSymbol name="BuildActiveProjectAsync" value="0x0103" />
       <IDSymbol name="BuildSolutionAsync" value="0x0104" />
+      <IDSymbol name="TestDependencyInjection" value="0x0105" />
     </GuidSymbol>
   </Symbols>
 </CommandTable>

--- a/test/VSSDK.TestExtension/VSSDK.TestExtension.csproj
+++ b/test/VSSDK.TestExtension/VSSDK.TestExtension.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <Compile Include="Commands\BuildActiveProjectAsyncCommand.cs" />
     <Compile Include="Commands\BuildSolutionAsyncCommand.cs" />
+    <Compile Include="Commands\DependencyInjectionCommand.cs" />
     <Compile Include="Commands\MultiInstanceWindowCommand.cs" />
     <Compile Include="Commands\RunnerWindowCommand.cs" />
     <Compile Include="Commands\ThemeWindowCommand.cs" />


### PR DESCRIPTION
*** This is a working POC that demonstrates the ability to integrate a DI container into the toolkit. Pertaining to discussion #122 ***

This adds a new interface `IToolkitServiceProvider` and implementation which wraps a `Microsoft.Extensions.DependencyInjection.IServiceProvider`.  This is added to the Visual Studio service collection so that you can retrieve this container using the regular VS methods, ie `VS.GetServiceAsync<SToolkitServiceProvider, IToolkitServiceProvider>`

~~While testing I noticed a slight inconvenience that would need to be documented: You have to add the `ProvdeCodeBase` attributes for the `Microsoft.Extensions.DependencyInjection.*` dlls to YOUR package instead of having them declared in the Toolkit package.  Maybe there's a workaround that I'm not aware of but these assembly level attributes aren't picked up by the implementing package and so the `*.pkgdef` does not include the appropriate references and Visual Studio throws an error if they are not defined in the implementing package.~~
This appears to be worked out by adding the `ProvideCodeBase` attributes to the `AssemblyInfo.cs` file.

Also, I was also able to use the most recent version (5.0.2) of the `Microsoft.Extensions.DependencyInjection` packages for v16 and v17 of the toolkit 😄. Versions 14 and 15 require v1.1.1 though.

~~Another potential issue that we may have is if there are multiple extensions installed that are based on the Toolkit. I'm not sure how Visual Studio would handle having multiple instances of the `SToolkitServiceProvider` registered in it's container.  Perhaps we could somehow register a generic service to the container that is based on the package class... something like:~~
This appears to work as I updated the PR to include this now:
```csharp
// Register in the VS container:
AddService(typeof(SToolkitServiceProvider<PackageTypeHere>), serviceCreatorCallback, true);

// Retrieve from the container:
IToolkitServiceProvider<PackageTypeHere> serviceProvider = await VS.GetRequiredServiceAsync<SToolkitServiceProvider<PackageTypeHere>, IToolkitServiceProvider>();
```

Another thought: We could also make this a completely separate package like `Community.VisualStudio.Toolkit.DependencyInjection` if we didn't want to pollute the main package with this.