### PR TITLE
Add Dependency Injection to the ToolkitPackage

### DIFF
--- a/Community.VisualStudio.Toolkit.sln
+++ b/Community.VisualStudio.Toolkit.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31321.278
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31512.422
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Community.VisualStudio.Toolkit.16.0", "src\Community.VisualStudio.Toolkit.16.0\Community.VisualStudio.Toolkit.16.0.csproj", "{38DC82EA-91D6-4360-B76C-995708EE43A3}"
 EndProject
@@ -26,9 +26,49 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Community.VisualStudio.Tool
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Community.VisualStudio.Toolkit.17.0", "src\Community.VisualStudio.Toolkit.17.0\Community.VisualStudio.Toolkit.17.0.csproj", "{D000C76D-4D0F-48F9-B5AB-5696C92CC7BD}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Dependency Injection", "Dependency Injection", "{1F7643C0-767C-4A40-A352-0BD660C3EBD5}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core", "Core", "{0F83D953-61A7-47DE-AEAE-1AE531D3C3E3}"
+	ProjectSection(SolutionItems) = preProject
+		src\DependencyInjection\Core\AssemblyInfo.cs = src\DependencyInjection\Core\AssemblyInfo.cs
+		src\DependencyInjection\Core\Community.VisualStudio.Toolkit.DependencyInjection.Core.props = src\DependencyInjection\Core\Community.VisualStudio.Toolkit.DependencyInjection.Core.props
+		src\DependencyInjection\Core\Community.VisualStudio.Toolkit.DependencyInjection.Core.targets = src\DependencyInjection\Core\Community.VisualStudio.Toolkit.DependencyInjection.Core.targets
+		src\DependencyInjection\Core\DependencyInjection.Core.Common.props = src\DependencyInjection\Core\DependencyInjection.Core.Common.props
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Microsoft", "Microsoft", "{698A7ACD-A78A-4067-B6AC-2DD15B74D714}"
+	ProjectSection(SolutionItems) = preProject
+		src\DependencyInjection\Microsoft\AssemblyInfo.cs = src\DependencyInjection\Microsoft\AssemblyInfo.cs
+		src\DependencyInjection\Microsoft\Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.props = src\DependencyInjection\Microsoft\Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.props
+		src\DependencyInjection\Microsoft\Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.targets = src\DependencyInjection\Microsoft\Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.targets
+		src\DependencyInjection\Microsoft\DependencyInjection.Microsoft.Common.props = src\DependencyInjection\Microsoft\DependencyInjection.Microsoft.Common.props
+	EndProjectSection
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.Shared", "src\DependencyInjection\Microsoft\Shared\Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.Shared.shproj", "{249F45FF-16E4-417B-99FA-686D20ED42C2}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Community.VisualStudio.Toolkit.DependencyInjection.Core.Shared", "src\DependencyInjection\Core\Shared\Community.VisualStudio.Toolkit.DependencyInjection.Core.Shared.shproj", "{BEB996A4-E7DA-4D44-A21C-493AAF842203}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Community.VisualStudio.Toolkit.DependencyInjection.Core.14.0", "src\DependencyInjection\Core\14.0\Community.VisualStudio.Toolkit.DependencyInjection.Core.14.0.csproj", "{17327EA4-F625-4052-BEA5-51AFD7997DA5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Community.VisualStudio.Toolkit.DependencyInjection.Core.15.0", "src\DependencyInjection\Core\15.0\Community.VisualStudio.Toolkit.DependencyInjection.Core.15.0.csproj", "{6CAC1ADB-7D98-4EF4-8012-91EEBDD6007F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Community.VisualStudio.Toolkit.DependencyInjection.Core.16.0", "src\DependencyInjection\Core\16.0\Community.VisualStudio.Toolkit.DependencyInjection.Core.16.0.csproj", "{45C54640-DF4D-432B-9029-0BFAB40D62A5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Community.VisualStudio.Toolkit.DependencyInjection.Core.17.0", "src\DependencyInjection\Core\17.0\Community.VisualStudio.Toolkit.DependencyInjection.Core.17.0.csproj", "{46F70315-990A-43DC-A28B-F61672050D7D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.14.0", "src\DependencyInjection\Microsoft\14.0\Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.14.0.csproj", "{23C52E2F-772C-4069-B81F-F47F6B25EF93}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.15.0", "src\DependencyInjection\Microsoft\15.0\Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.15.0.csproj", "{026F18E6-62D7-40EF-847A-2F1B247E0FBA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.16.0", "src\DependencyInjection\Microsoft\16.0\Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.16.0.csproj", "{8B7860D7-7AAC-4868-97D4-EF998B07AB56}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.17.0", "src\DependencyInjection\Microsoft\17.0\Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.17.0.csproj", "{C54AD939-B3B3-4234-B3D0-4929E32B7B72}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		src\DependencyInjection\Microsoft\Shared\Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.Shared.projitems*{249f45ff-16e4-417b-99fa-686d20ed42c2}*SharedItemsImports = 13
 		src\Community.VisualStudio.Toolkit.Shared\VSSDK.Helpers.Shared.projitems*{5ec463ac-24cb-443e-9ff9-91b7ecb1f822}*SharedItemsImports = 13
+		src\DependencyInjection\Core\Shared\Community.VisualStudio.Toolkit.DependencyInjection.Core.Shared.projitems*{beb996a4-e7da-4d44-a21c-493aaf842203}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,9 +95,55 @@ Global
 		{D000C76D-4D0F-48F9-B5AB-5696C92CC7BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D000C76D-4D0F-48F9-B5AB-5696C92CC7BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D000C76D-4D0F-48F9-B5AB-5696C92CC7BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{17327EA4-F625-4052-BEA5-51AFD7997DA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{17327EA4-F625-4052-BEA5-51AFD7997DA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{17327EA4-F625-4052-BEA5-51AFD7997DA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{17327EA4-F625-4052-BEA5-51AFD7997DA5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6CAC1ADB-7D98-4EF4-8012-91EEBDD6007F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6CAC1ADB-7D98-4EF4-8012-91EEBDD6007F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6CAC1ADB-7D98-4EF4-8012-91EEBDD6007F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6CAC1ADB-7D98-4EF4-8012-91EEBDD6007F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{45C54640-DF4D-432B-9029-0BFAB40D62A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{45C54640-DF4D-432B-9029-0BFAB40D62A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{45C54640-DF4D-432B-9029-0BFAB40D62A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{45C54640-DF4D-432B-9029-0BFAB40D62A5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{46F70315-990A-43DC-A28B-F61672050D7D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{46F70315-990A-43DC-A28B-F61672050D7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{46F70315-990A-43DC-A28B-F61672050D7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{46F70315-990A-43DC-A28B-F61672050D7D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{23C52E2F-772C-4069-B81F-F47F6B25EF93}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{23C52E2F-772C-4069-B81F-F47F6B25EF93}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{23C52E2F-772C-4069-B81F-F47F6B25EF93}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{23C52E2F-772C-4069-B81F-F47F6B25EF93}.Release|Any CPU.Build.0 = Release|Any CPU
+		{026F18E6-62D7-40EF-847A-2F1B247E0FBA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{026F18E6-62D7-40EF-847A-2F1B247E0FBA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{026F18E6-62D7-40EF-847A-2F1B247E0FBA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{026F18E6-62D7-40EF-847A-2F1B247E0FBA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8B7860D7-7AAC-4868-97D4-EF998B07AB56}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8B7860D7-7AAC-4868-97D4-EF998B07AB56}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8B7860D7-7AAC-4868-97D4-EF998B07AB56}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8B7860D7-7AAC-4868-97D4-EF998B07AB56}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C54AD939-B3B3-4234-B3D0-4929E32B7B72}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C54AD939-B3B3-4234-B3D0-4929E32B7B72}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C54AD939-B3B3-4234-B3D0-4929E32B7B72}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C54AD939-B3B3-4234-B3D0-4929E32B7B72}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{0F83D953-61A7-47DE-AEAE-1AE531D3C3E3} = {1F7643C0-767C-4A40-A352-0BD660C3EBD5}
+		{698A7ACD-A78A-4067-B6AC-2DD15B74D714} = {1F7643C0-767C-4A40-A352-0BD660C3EBD5}
+		{249F45FF-16E4-417B-99FA-686D20ED42C2} = {698A7ACD-A78A-4067-B6AC-2DD15B74D714}
+		{BEB996A4-E7DA-4D44-A21C-493AAF842203} = {0F83D953-61A7-47DE-AEAE-1AE531D3C3E3}
+		{17327EA4-F625-4052-BEA5-51AFD7997DA5} = {0F83D953-61A7-47DE-AEAE-1AE531D3C3E3}
+		{6CAC1ADB-7D98-4EF4-8012-91EEBDD6007F} = {0F83D953-61A7-47DE-AEAE-1AE531D3C3E3}
+		{45C54640-DF4D-432B-9029-0BFAB40D62A5} = {0F83D953-61A7-47DE-AEAE-1AE531D3C3E3}
+		{46F70315-990A-43DC-A28B-F61672050D7D} = {0F83D953-61A7-47DE-AEAE-1AE531D3C3E3}
+		{23C52E2F-772C-4069-B81F-F47F6B25EF93} = {698A7ACD-A78A-4067-B6AC-2DD15B74D714}
+		{026F18E6-62D7-40EF-847A-2F1B247E0FBA} = {698A7ACD-A78A-4067-B6AC-2DD15B74D714}
+		{8B7860D7-7AAC-4868-97D4-EF998B07AB56} = {698A7ACD-A78A-4067-B6AC-2DD15B74D714}
+		{C54AD939-B3B3-4234-B3D0-4929E32B7B72} = {698A7ACD-A78A-4067-B6AC-2DD15B74D714}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E0DD67C0-2617-498C-81F0-A5E4FF5831F1}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,16 @@ build_script:
   - ps: dotnet build src/Community.VisualStudio.Toolkit.16.0/Community.VisualStudio.Toolkit.16.0.csproj /p:configuration=Release /p:ContinuousIntegrationBuild=true /p:Version=16.0.75.$($env:appveyor_build_number)-pre
   - ps: dotnet build src/Community.VisualStudio.Toolkit.17.0/Community.VisualStudio.Toolkit.17.0.csproj /p:configuration=Release /p:ContinuousIntegrationBuild=true /p:Version=17.0.75.$($env:appveyor_build_number)-pre
 
+  - ps: dotnet build src/DependencyInjection/Core/14.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.14.0.csproj /p:configuration=Release /p:ContinuousIntegrationBuild=true /p:Version=14.0.75.$($env:appveyor_build_number)-pre
+  - ps: dotnet build src/DependencyInjection/Core/15.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.15.0.csproj /p:configuration=Release /p:ContinuousIntegrationBuild=true /p:Version=14.0.75.$($env:appveyor_build_number)-pre
+  - ps: dotnet build src/DependencyInjection/Core/16.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.16.0.csproj /p:configuration=Release /p:ContinuousIntegrationBuild=true /p:Version=14.0.75.$($env:appveyor_build_number)-pre
+  - ps: dotnet build src/DependencyInjection/Core/17.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.17.0.csproj /p:configuration=Release /p:ContinuousIntegrationBuild=true /p:Version=14.0.75.$($env:appveyor_build_number)-pre
+
+  - ps: dotnet build src/DependencyInjection/Microsoft/14.0/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.14.0.csproj /p:configuration=Release /p:ContinuousIntegrationBuild=true /p:Version=14.0.75.$($env:appveyor_build_number)-pre
+  - ps: dotnet build src/DependencyInjection/Microsoft/15.0/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.15.0.csproj /p:configuration=Release /p:ContinuousIntegrationBuild=true /p:Version=14.0.75.$($env:appveyor_build_number)-pre
+  - ps: dotnet build src/DependencyInjection/Microsoft/16.0/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.16.0.csproj /p:configuration=Release /p:ContinuousIntegrationBuild=true /p:Version=14.0.75.$($env:appveyor_build_number)-pre
+  - ps: dotnet build src/DependencyInjection/Microsoft/17.0/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.17.0.csproj /p:configuration=Release /p:ContinuousIntegrationBuild=true /p:Version=14.0.75.$($env:appveyor_build_number)-pre
+
 test: off
 
 artifacts:

--- a/src/DependencyInjection/Core/14.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.14.0.csproj
+++ b/src/DependencyInjection/Core/14.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.14.0.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/DependencyInjection/Core/14.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.14.0.csproj
+++ b/src/DependencyInjection/Core/14.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.14.0.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\DependencyInjection.Core.Common.props" />
+  
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <Version>14.0</Version>
+    <DefineConstants>VS14</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Community.VisualStudio.Toolkit.14.0\Community.VisualStudio.Toolkit.14.0.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DependencyInjection/Core/15.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.15.0.csproj
+++ b/src/DependencyInjection/Core/15.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.15.0.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/DependencyInjection/Core/15.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.15.0.csproj
+++ b/src/DependencyInjection/Core/15.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.15.0.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\DependencyInjection.Core.Common.props" />
+  
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <Version>15.0</Version>
+    <DefineConstants>VS15</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Community.VisualStudio.Toolkit.15.0\Community.VisualStudio.Toolkit.15.0.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DependencyInjection/Core/16.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.16.0.csproj
+++ b/src/DependencyInjection/Core/16.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.16.0.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\DependencyInjection.Core.Common.props" />
+  
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <Version>16.0</Version>
+    <DefineConstants>VS16</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Community.VisualStudio.Toolkit.16.0\Community.VisualStudio.Toolkit.16.0.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DependencyInjection/Core/16.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.16.0.csproj
+++ b/src/DependencyInjection/Core/16.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.16.0.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/DependencyInjection/Core/17.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.17.0.csproj
+++ b/src/DependencyInjection/Core/17.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.17.0.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/DependencyInjection/Core/17.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.17.0.csproj
+++ b/src/DependencyInjection/Core/17.0/Community.VisualStudio.Toolkit.DependencyInjection.Core.17.0.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\DependencyInjection.Core.Common.props" />
+  
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <Version>17.0</Version>
+    <DefineConstants>VS17</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Community.VisualStudio.Toolkit.17.0\Community.VisualStudio.Toolkit.17.0.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DependencyInjection/Core/AssemblyInfo.cs
+++ b/src/DependencyInjection/Core/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+// This will add the toolkit assembly to Visual Studio's probing path.
+// Without it, Visual Studio is unable to find the assembly and the extension will fail to load.
+using Microsoft.VisualStudio.Shell;
+
+[assembly: ProvideCodeBase(AssemblyName = "Community.VisualStudio.Toolkit")]
+[assembly: ProvideCodeBase(AssemblyName = "Community.VisualStudio.Toolkit.DependencyInjection")]
+[assembly: ProvideCodeBase(AssemblyName = "Microsoft.Extensions.DependencyInjection")]
+[assembly: ProvideCodeBase(AssemblyName = "Microsoft.Extensions.DependencyInjection.Abstractions")]

--- a/src/DependencyInjection/Core/AssemblyInfo.cs
+++ b/src/DependencyInjection/Core/AssemblyInfo.cs
@@ -4,5 +4,4 @@ using Microsoft.VisualStudio.Shell;
 
 [assembly: ProvideCodeBase(AssemblyName = "Community.VisualStudio.Toolkit")]
 [assembly: ProvideCodeBase(AssemblyName = "Community.VisualStudio.Toolkit.DependencyInjection")]
-[assembly: ProvideCodeBase(AssemblyName = "Microsoft.Extensions.DependencyInjection")]
 [assembly: ProvideCodeBase(AssemblyName = "Microsoft.Extensions.DependencyInjection.Abstractions")]

--- a/src/DependencyInjection/Core/AssemblyInfo.cs
+++ b/src/DependencyInjection/Core/AssemblyInfo.cs
@@ -3,5 +3,5 @@
 using Microsoft.VisualStudio.Shell;
 
 [assembly: ProvideCodeBase(AssemblyName = "Community.VisualStudio.Toolkit")]
-[assembly: ProvideCodeBase(AssemblyName = "Community.VisualStudio.Toolkit.DependencyInjection")]
+[assembly: ProvideCodeBase(AssemblyName = "Community.VisualStudio.Toolkit.DependencyInjection.Core")]
 [assembly: ProvideCodeBase(AssemblyName = "Microsoft.Extensions.DependencyInjection.Abstractions")]

--- a/src/DependencyInjection/Core/Community.VisualStudio.Toolkit.DependencyInjection.Core.props
+++ b/src/DependencyInjection/Core/Community.VisualStudio.Toolkit.DependencyInjection.Core.props
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+    <ItemGroup>
+      <Content Include="$(MSBuildThisFileDirectory)..\lib\*\*.dll" CopyToOutputDirectory="PreserveNewest" Visible="false">
+        <Link>Community.VisualStudio.Toolkit.DependencyInjection.Core.dll</Link>
+        <IncludeInVSIX>true</IncludeInVSIX>
+      </Content>
+
+      <Compile Include="$(MSBuildThisFileDirectory)*.cs" />
+    </ItemGroup>
+
+</Project>

--- a/src/DependencyInjection/Core/Community.VisualStudio.Toolkit.DependencyInjection.Core.targets
+++ b/src/DependencyInjection/Core/Community.VisualStudio.Toolkit.DependencyInjection.Core.targets
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <Target Name="ExtensibilityEssentialsCheck" BeforeTargets="PrepareForBuild">
+    <ItemGroup>
+      <!-- 
+      We only want to check if the Extensibility Essentials extension is installed for VSIX projects,
+      because that is the only type of projects that the extension will add the build property for.
+      This requires two steps because we cannot filter an item group as it's created from a property.
+      First, turn the `ProjectTypeGuids` property into a set of items, then create another set by 
+      filtering out any types that are not the VSIX project type. 
+      -->
+      <ExtensibilityEssentialsProjectTypes Include="$(ProjectTypeGuids)"/>
+      <ExtensibilityEssentialsVsixProjectTypes Include="@(ExtensibilityEssentialsProjectTypes)" Condition="'%(Identity)' == '{82b43b9b-a64c-4715-b499-d71e9ca2bd60}'"/>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <!-- 
+      Determine whether a `HelpLink` property is supported on Warning and Error tasks. 
+      The ability to supply a `HelpLink` property was added in MSBuild v16.8.
+      -->
+      <MSBuildMajorVersion>$([System.Version]::Parse($(MSBuildVersion)).Major)</MSBuildMajorVersion>
+      <MSBuildMinorVersion>$([System.Version]::Parse($(MSBuildVersion)).Minor)</MSBuildMinorVersion>
+      <WarningsAndErrorsHaveHelpLink Condition="($(MSBuildMajorVersion) > 16) or ($(MSBuildMajorVersion) == 16 and $(MSBuildMinorVersion) >= 8)">true</WarningsAndErrorsHaveHelpLink>
+    </PropertyGroup>
+      
+    <PropertyGroup>
+      <!-- Message text. -->
+      <ExtensibilityEssentialsInfoText Condition="'$(ExtensibilityEssentialsInfoText)' == ''">The 'Extensibility Essentials' extension makes extension development easier.</ExtensibilityEssentialsInfoText>
+      <ExtensibilityEssentialsWarningText Condition="'$(ExtensibilityEssentialsWarningText)' == ''">The 'Extensibility Essentials' extension is recommended for this project.</ExtensibilityEssentialsWarningText>
+      <ExtensibilityEssentialsErrorText Condition="'$(ExtensibilityEssentialsErrorText)' == ''">The 'Extensibility Essentials' extension is required for this project.</ExtensibilityEssentialsErrorText>
+
+      <!-- Message metadata. -->
+      <ExtensibilityEssentialsCode>VSTK001</ExtensibilityEssentialsCode>
+      <ExtensibilityEssentialsHelpLink Condition="'$(VisualStudioVersion)' == '15.0'">https://marketplace.visualstudio.com/items?itemName=MadsKristensen.ExtensibilityEssentials</ExtensibilityEssentialsHelpLink>
+      <ExtensibilityEssentialsHelpLink Condition="'$(VisualStudioVersion)' == '16.0'">https://marketplace.visualstudio.com/items?itemName=MadsKristensen.ExtensibilityEssentials2019</ExtensibilityEssentialsHelpLink>
+    
+      <!-- Default level. -->
+      <ExtensibilityEssentialsLevel Condition="'$(ExtensibilityEssentialsLevel)' == ''">Info</ExtensibilityEssentialsLevel>
+
+      <!--
+      Visibility Calculation. Only show the message, warning or error for VSIX projects, and only
+      when building them inside Visual Studio so that we don't break command line builds (because
+      the extension won't be able to provide the `ExtensibilityEssentialsInstalled` property).
+      Also omit the message for CI builds, just in case Visual Studio is being used for CI. 
+      -->
+      <IsVsixProject Condition="'@(ExtensibilityEssentialsVsixProjectTypes->Count())' &gt; 0">true</IsVsixProject>
+      <IsExtensibilityEssentialsMissing Condition="'$(IsVsixProject)' == 'true' and '$(CI)' == '' and '$(BuildingInsideVisualStudio)' == 'true' and '$(ExtensibilityEssentialsInstalled)' != 'true'">true</IsExtensibilityEssentialsMissing>
+    </PropertyGroup>
+
+    <!-- 
+    Verify that a valid "level" has been specified. This protects against the 
+    user making a mistake and not realizing that the message will never be shown.
+    -->
+    <Warning
+      Condition="'$(ExtensibilityEssentialsLevel)' != 'None' and '$(ExtensibilityEssentialsLevel)' != 'Info' and '$(ExtensibilityEssentialsLevel)' != 'Warning' and '$(ExtensibilityEssentialsLevel)' != 'Error'"
+      Text="The 'ExtensibilityEssentialsLevel' property value '$(ExtensibilityEssentialsLevel)' is invalid. Valid values are 'None', 'Info', 'Warning' or 'Error'."
+      />
+    
+    <!-- 
+    Messages marked as `IsCritical` appear in Visual Studio's Error List under the 'Messages' tab. 
+    Note that the Message task does not support the `HelpLink` property. :(
+    -->
+    <Message
+      Condition="'$(IsExtensibilityEssentialsMissing)' == 'true' and '$(ExtensibilityEssentialsLevel)' == 'Info'"
+      Text="$(ExtensibilityEssentialsInfoText)"
+      Code="$(ExtensibilityEssentialsCode)"
+      IsCritical="true"
+      />
+    
+    <!-- For MSBuild versions that do not support `HelpLink`. -->
+    <Warning 
+      Condition="'$(WarningsAndErrorsHaveHelpLink)' != 'true' and '$(IsExtensibilityEssentialsMissing)' == 'true' and '$(ExtensibilityEssentialsLevel)' == 'Warning'" 
+      Text="$(ExtensibilityEssentialsWarningText)" 
+      Code="$(ExtensibilityEssentialsCode)"
+      />
+
+    <Error 
+      Condition="'$(WarningsAndErrorsHaveHelpLink)' != 'true' and '$(IsExtensibilityEssentialsMissing)' == 'true' and '$(ExtensibilityEssentialsLevel)' == 'Error'" 
+      Text="$(ExtensibilityEssentialsErrorText)" 
+      Code="$(ExtensibilityEssentialsCode)"
+      />
+      
+    <!-- For MSBuild versions that support `HelpLink`. -->
+    <Warning 
+      Condition="'$(WarningsAndErrorsHaveHelpLink)' == 'true' and '$(IsExtensibilityEssentialsMissing)' == 'true' and '$(ExtensibilityEssentialsLevel)' == 'Warning'" 
+      Text="$(ExtensibilityEssentialsWarningText)" 
+      Code="$(ExtensibilityEssentialsCode)"
+      HelpLink="$(ExtensibilityEssentialsHelpLink)"
+      />
+
+    <Error 
+      Condition="'$(WarningsAndErrorsHaveHelpLink)' == 'true' and '$(IsExtensibilityEssentialsMissing)' == 'true' and '$(ExtensibilityEssentialsLevel)' == 'Error'" 
+      Text="$(ExtensibilityEssentialsErrorText)" 
+      Code="$(ExtensibilityEssentialsCode)"
+      HelpLink="$(ExtensibilityEssentialsHelpLink)"
+      />
+  </Target>
+
+</Project>

--- a/src/DependencyInjection/Core/DependencyInjection.Core.Common.props
+++ b/src/DependencyInjection/Core/DependencyInjection.Core.Common.props
@@ -1,0 +1,52 @@
+<Project>
+
+  <PropertyGroup>
+    <Authors>VSIX Community</Authors>
+    <Owners>VSIX Community</Owners>
+    <Copyright>© Mads Kristensen. All rights reserved.</Copyright>
+    <PackageProjectUrl>https://github.com/VsixCommunity/Community.VisualStudio.Toolkit</PackageProjectUrl>
+    <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <DebugType>embedded</DebugType>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugType>portable</DebugType>
+    
+    <PackageId>Community.VisualStudio.Toolkit.DependencyInjection.Core</PackageId>
+    <AssemblyName>Community.VisualStudio.Toolkit.DependencyInjection.Core</AssemblyName>
+    <PackageDescription>Adds Dependency Injection to the Community.VisualStudio.Toolkit</PackageDescription>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageIcon>Icon.png</PackageIcon>
+    <PackageTags>VisualStudio, VSSDK, SDK</PackageTags>
+    <RootNamespace>Community.VisualStudio.Toolkit.DependencyInjection.Core</RootNamespace>
+
+    <LangVersion>9</LangVersion>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>../../../key.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\..\Icon.png" Link="Icon.png" Pack="true" PackagePath="" Visible="false" />
+    <None Include="../Community.VisualStudio.Toolkit.DependencyInjection.Core.props" Pack="true" PackagePath="build" Visible="false" />
+    <None Include="../Community.VisualStudio.Toolkit.DependencyInjection.Core.targets" Pack="true" PackagePath="build" Visible="false" />
+    <None Include="../AssemblyInfo.cs" Pack="true" PackagePath="build" Visible="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System.Design" />
+    <Reference Include="System.Windows" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)Shared\Community.VisualStudio.Toolkit.DependencyInjection.Core.Shared.projitems" Label="Shared" />
+
+</Project>

--- a/src/DependencyInjection/Core/Shared/Community.VisualStudio.Toolkit.DependencyInjection.Core.Shared.projitems
+++ b/src/DependencyInjection/Core/Shared/Community.VisualStudio.Toolkit.DependencyInjection.Core.Shared.projitems
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>beb996a4-e7da-4d44-a21c-493aaf842203</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>Community.VisualStudio.Toolkit.DependencyInjection.Core</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)DIToolkitPackage.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)IToolkitServiceProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SToolkitServiceProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ToolkitServiceProvider.cs" />
+  </ItemGroup>
+</Project>

--- a/src/DependencyInjection/Core/Shared/Community.VisualStudio.Toolkit.DependencyInjection.Core.Shared.shproj
+++ b/src/DependencyInjection/Core/Shared/Community.VisualStudio.Toolkit.DependencyInjection.Core.Shared.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>beb996a4-e7da-4d44-a21c-493aaf842203</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="Community.VisualStudio.Toolkit.DependencyInjection.Core.Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/src/DependencyInjection/Core/Shared/DIToolkitPackage.cs
+++ b/src/DependencyInjection/Core/Shared/DIToolkitPackage.cs
@@ -12,7 +12,7 @@ namespace Community.VisualStudio.Toolkit.DependencyInjection
     /// </summary>
     /// <typeparam name="TPackage"></typeparam>
     [ProvideService(typeof(SToolkitServiceProvider<>), IsAsyncQueryable = true)]
-    public class DIToolkitPackage<TPackage> : ToolkitPackage
+    public abstract class DIToolkitPackage<TPackage> : ToolkitPackage
         where TPackage : AsyncPackage
     {
         /// <summary>
@@ -30,9 +30,11 @@ namespace Community.VisualStudio.Toolkit.DependencyInjection
         {
             await base.InitializeAsync(cancellationToken, progress);
 
-            ServiceCollection services = new ServiceCollection();
+            IServiceCollection services = this.CreateServiceCollection();
             InitializeServices(services);
-            ServiceProvider = new ToolkitServiceProvider<TPackage>(services);
+
+            IServiceProvider serviceProvider = BuildServiceProvider(services);
+            ServiceProvider = new ToolkitServiceProvider<TPackage>(serviceProvider);
 
             // Add the IToolkitServiceProvider to the VS IServiceProvider
             AsyncServiceCreatorCallback serviceCreatorCallback = (sc, ct, t) =>
@@ -44,10 +46,23 @@ namespace Community.VisualStudio.Toolkit.DependencyInjection
         }
 
         /// <summary>
+        /// Create the service collection.
+        /// </summary>
+        /// <returns></returns>
+        protected abstract IServiceCollection CreateServiceCollection();
+
+        /// <summary>
+        /// Builds the service collection
+        /// </summary>
+        /// <param name="serviceCollection"></param>
+        /// <returns></returns>
+        protected abstract IServiceProvider BuildServiceProvider(IServiceCollection serviceCollection);
+
+        /// <summary>
         /// Initialize the services in the DI container.
         /// </summary>
         /// <param name="services"></param>
-        protected virtual void InitializeServices(ServiceCollection services)
+        protected virtual void InitializeServices(IServiceCollection services)
         {
             // Nothing
         }

--- a/src/DependencyInjection/Core/Shared/DIToolkitPackage.cs
+++ b/src/DependencyInjection/Core/Shared/DIToolkitPackage.cs
@@ -1,0 +1,55 @@
+﻿using System.Threading;
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+using Community.VisualStudio.Toolkit.DependencyInjection.Core;
+
+namespace Community.VisualStudio.Toolkit.DependencyInjection
+{
+    /// <summary>
+    /// Package that contains a DI service container.
+    /// </summary>
+    /// <typeparam name="TPackage"></typeparam>
+    [ProvideService(typeof(SToolkitServiceProvider<>), IsAsyncQueryable = true)]
+    public class DIToolkitPackage<TPackage> : ToolkitPackage
+        where TPackage : AsyncPackage
+    {
+        /// <summary>
+        /// Custom ServiceProvider for the package.
+        /// </summary>
+        public IToolkitServiceProvider<TPackage> ServiceProvider { get; private set; } = null!; // This property is initialized in `InitializeAsync`, so it's never actually null.
+
+        /// <summary>
+        /// Initializes the <see cref="AsyncPackage"/>
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <param name="progress"></param>
+        /// <returns></returns>
+        protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+        {
+            await base.InitializeAsync(cancellationToken, progress);
+
+            ServiceCollection services = new ServiceCollection();
+            InitializeServices(services);
+            ServiceProvider = new ToolkitServiceProvider<TPackage>(services);
+
+            // Add the IToolkitServiceProvider to the VS IServiceProvider
+            AsyncServiceCreatorCallback serviceCreatorCallback = (sc, ct, t) =>
+            {
+                return Task.FromResult((object)this.ServiceProvider);
+            };
+
+            AddService(typeof(SToolkitServiceProvider<TPackage>), serviceCreatorCallback, true);
+        }
+
+        /// <summary>
+        /// Initialize the services in the DI container.
+        /// </summary>
+        /// <param name="services"></param>
+        protected virtual void InitializeServices(ServiceCollection services)
+        {
+            // Nothing
+        }
+    }
+}

--- a/src/DependencyInjection/Core/Shared/IToolkitServiceProvider.cs
+++ b/src/DependencyInjection/Core/Shared/IToolkitServiceProvider.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Microsoft.VisualStudio.Shell;
+
+namespace Community.VisualStudio.Toolkit.DependencyInjection.Core
+{
+    /// <summary>
+    /// Service provider
+    /// </summary>
+    /// <typeparam name="TPackage">Type of the implementing package.</typeparam>
+    public interface IToolkitServiceProvider<TPackage> : IServiceProvider
+         where TPackage : AsyncPackage
+    {
+    }
+}

--- a/src/DependencyInjection/Core/Shared/SToolkitServiceProvider.cs
+++ b/src/DependencyInjection/Core/Shared/SToolkitServiceProvider.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.VisualStudio.Shell;
+
+namespace Community.VisualStudio.Toolkit.DependencyInjection.Core
+{
+    /// <summary>
+    /// Placeholder interface for registering the <see cref="IToolkitServiceProvider{TPackage}"/> in the main Visual Studio service provider.
+    /// </summary>
+    /// <typeparam name="TPackage">Type of the implementing package.</typeparam>
+    public interface SToolkitServiceProvider<TPackage>
+        where TPackage : AsyncPackage
+    {
+    }
+}

--- a/src/DependencyInjection/Core/Shared/ToolkitServiceProvider.cs
+++ b/src/DependencyInjection/Core/Shared/ToolkitServiceProvider.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.Shell;
+
+namespace Community.VisualStudio.Toolkit.DependencyInjection.Core
+{
+    internal class ToolkitServiceProvider<TPackage> : IToolkitServiceProvider<TPackage>
+         where TPackage : AsyncPackage
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public ToolkitServiceProvider(ServiceCollection services)
+        {
+            _serviceProvider = services.BuildServiceProvider();
+        }
+
+        public object GetService(Type serviceType)
+        {
+            return _serviceProvider.GetService(serviceType);
+        }
+    }
+}

--- a/src/DependencyInjection/Core/Shared/ToolkitServiceProvider.cs
+++ b/src/DependencyInjection/Core/Shared/ToolkitServiceProvider.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.Shell;
 
 namespace Community.VisualStudio.Toolkit.DependencyInjection.Core
@@ -9,9 +8,9 @@ namespace Community.VisualStudio.Toolkit.DependencyInjection.Core
     {
         private readonly IServiceProvider _serviceProvider;
 
-        public ToolkitServiceProvider(ServiceCollection services)
+        public ToolkitServiceProvider(IServiceProvider services)
         {
-            _serviceProvider = services.BuildServiceProvider();
+            _serviceProvider = services;
         }
 
         public object GetService(Type serviceType)

--- a/src/DependencyInjection/Microsoft/14.0/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.14.0.csproj
+++ b/src/DependencyInjection/Microsoft/14.0/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.14.0.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\DependencyInjection.Microsoft.Common.props" />
+  
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <Version>14.0</Version>
+    <DefineConstants>VS14</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\14.0\Community.VisualStudio.Toolkit.DependencyInjection.Core.14.0.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DependencyInjection/Microsoft/15.0/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.15.0.csproj
+++ b/src/DependencyInjection/Microsoft/15.0/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.15.0.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\DependencyInjection.Microsoft.Common.props" />
+  
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <Version>15.0</Version>
+    <DefineConstants>VS15</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\15.0\Community.VisualStudio.Toolkit.DependencyInjection.Core.15.0.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DependencyInjection/Microsoft/16.0/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.16.0.csproj
+++ b/src/DependencyInjection/Microsoft/16.0/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.16.0.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\DependencyInjection.Microsoft.Common.props" />
+  
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <Version>16.0</Version>
+    <DefineConstants>VS16</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\16.0\Community.VisualStudio.Toolkit.DependencyInjection.Core.16.0.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DependencyInjection/Microsoft/17.0/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.17.0.csproj
+++ b/src/DependencyInjection/Microsoft/17.0/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.17.0.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\DependencyInjection.Microsoft.Common.props" />
+  
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <Version>17.0</Version>
+    <DefineConstants>VS17</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\17.0\Community.VisualStudio.Toolkit.DependencyInjection.Core.17.0.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DependencyInjection/Microsoft/AssemblyInfo.cs
+++ b/src/DependencyInjection/Microsoft/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 using Microsoft.VisualStudio.Shell;
 
 [assembly: ProvideCodeBase(AssemblyName = "Community.VisualStudio.Toolkit")]
-[assembly: ProvideCodeBase(AssemblyName = "Community.VisualStudio.Toolkit.DependencyInjection")]
+[assembly: ProvideCodeBase(AssemblyName = "Community.VisualStudio.Toolkit.DependencyInjection.Core")]
 [assembly: ProvideCodeBase(AssemblyName = "Community.VisualStudio.Toolkit.DependencyInjection.Microsoft")]
 [assembly: ProvideCodeBase(AssemblyName = "Microsoft.Extensions.DependencyInjection")]
 [assembly: ProvideCodeBase(AssemblyName = "Microsoft.Extensions.DependencyInjection.Abstractions")]

--- a/src/DependencyInjection/Microsoft/AssemblyInfo.cs
+++ b/src/DependencyInjection/Microsoft/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+// This will add the toolkit assembly to Visual Studio's probing path.
+// Without it, Visual Studio is unable to find the assembly and the extension will fail to load.
+using Microsoft.VisualStudio.Shell;
+
+[assembly: ProvideCodeBase(AssemblyName = "Community.VisualStudio.Toolkit")]
+[assembly: ProvideCodeBase(AssemblyName = "Community.VisualStudio.Toolkit.DependencyInjection")]
+[assembly: ProvideCodeBase(AssemblyName = "Community.VisualStudio.Toolkit.DependencyInjection.Microsoft")]
+[assembly: ProvideCodeBase(AssemblyName = "Microsoft.Extensions.DependencyInjection")]
+[assembly: ProvideCodeBase(AssemblyName = "Microsoft.Extensions.DependencyInjection.Abstractions")]

--- a/src/DependencyInjection/Microsoft/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.props
+++ b/src/DependencyInjection/Microsoft/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.props
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+    <ItemGroup>
+      <Content Include="$(MSBuildThisFileDirectory)..\lib\*\*.dll" CopyToOutputDirectory="PreserveNewest" Visible="false">
+        <Link>Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.dll</Link>
+        <IncludeInVSIX>true</IncludeInVSIX>
+      </Content>
+
+      <Compile Include="$(MSBuildThisFileDirectory)*.cs" />
+    </ItemGroup>
+
+</Project>

--- a/src/DependencyInjection/Microsoft/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.targets
+++ b/src/DependencyInjection/Microsoft/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.targets
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <Target Name="ExtensibilityEssentialsCheck" BeforeTargets="PrepareForBuild">
+    <ItemGroup>
+      <!-- 
+      We only want to check if the Extensibility Essentials extension is installed for VSIX projects,
+      because that is the only type of projects that the extension will add the build property for.
+      This requires two steps because we cannot filter an item group as it's created from a property.
+      First, turn the `ProjectTypeGuids` property into a set of items, then create another set by 
+      filtering out any types that are not the VSIX project type. 
+      -->
+      <ExtensibilityEssentialsProjectTypes Include="$(ProjectTypeGuids)"/>
+      <ExtensibilityEssentialsVsixProjectTypes Include="@(ExtensibilityEssentialsProjectTypes)" Condition="'%(Identity)' == '{82b43b9b-a64c-4715-b499-d71e9ca2bd60}'"/>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <!-- 
+      Determine whether a `HelpLink` property is supported on Warning and Error tasks. 
+      The ability to supply a `HelpLink` property was added in MSBuild v16.8.
+      -->
+      <MSBuildMajorVersion>$([System.Version]::Parse($(MSBuildVersion)).Major)</MSBuildMajorVersion>
+      <MSBuildMinorVersion>$([System.Version]::Parse($(MSBuildVersion)).Minor)</MSBuildMinorVersion>
+      <WarningsAndErrorsHaveHelpLink Condition="($(MSBuildMajorVersion) > 16) or ($(MSBuildMajorVersion) == 16 and $(MSBuildMinorVersion) >= 8)">true</WarningsAndErrorsHaveHelpLink>
+    </PropertyGroup>
+      
+    <PropertyGroup>
+      <!-- Message text. -->
+      <ExtensibilityEssentialsInfoText Condition="'$(ExtensibilityEssentialsInfoText)' == ''">The 'Extensibility Essentials' extension makes extension development easier.</ExtensibilityEssentialsInfoText>
+      <ExtensibilityEssentialsWarningText Condition="'$(ExtensibilityEssentialsWarningText)' == ''">The 'Extensibility Essentials' extension is recommended for this project.</ExtensibilityEssentialsWarningText>
+      <ExtensibilityEssentialsErrorText Condition="'$(ExtensibilityEssentialsErrorText)' == ''">The 'Extensibility Essentials' extension is required for this project.</ExtensibilityEssentialsErrorText>
+
+      <!-- Message metadata. -->
+      <ExtensibilityEssentialsCode>VSTK001</ExtensibilityEssentialsCode>
+      <ExtensibilityEssentialsHelpLink Condition="'$(VisualStudioVersion)' == '15.0'">https://marketplace.visualstudio.com/items?itemName=MadsKristensen.ExtensibilityEssentials</ExtensibilityEssentialsHelpLink>
+      <ExtensibilityEssentialsHelpLink Condition="'$(VisualStudioVersion)' == '16.0'">https://marketplace.visualstudio.com/items?itemName=MadsKristensen.ExtensibilityEssentials2019</ExtensibilityEssentialsHelpLink>
+    
+      <!-- Default level. -->
+      <ExtensibilityEssentialsLevel Condition="'$(ExtensibilityEssentialsLevel)' == ''">Info</ExtensibilityEssentialsLevel>
+
+      <!--
+      Visibility Calculation. Only show the message, warning or error for VSIX projects, and only
+      when building them inside Visual Studio so that we don't break command line builds (because
+      the extension won't be able to provide the `ExtensibilityEssentialsInstalled` property).
+      Also omit the message for CI builds, just in case Visual Studio is being used for CI. 
+      -->
+      <IsVsixProject Condition="'@(ExtensibilityEssentialsVsixProjectTypes->Count())' &gt; 0">true</IsVsixProject>
+      <IsExtensibilityEssentialsMissing Condition="'$(IsVsixProject)' == 'true' and '$(CI)' == '' and '$(BuildingInsideVisualStudio)' == 'true' and '$(ExtensibilityEssentialsInstalled)' != 'true'">true</IsExtensibilityEssentialsMissing>
+    </PropertyGroup>
+
+    <!-- 
+    Verify that a valid "level" has been specified. This protects against the 
+    user making a mistake and not realizing that the message will never be shown.
+    -->
+    <Warning
+      Condition="'$(ExtensibilityEssentialsLevel)' != 'None' and '$(ExtensibilityEssentialsLevel)' != 'Info' and '$(ExtensibilityEssentialsLevel)' != 'Warning' and '$(ExtensibilityEssentialsLevel)' != 'Error'"
+      Text="The 'ExtensibilityEssentialsLevel' property value '$(ExtensibilityEssentialsLevel)' is invalid. Valid values are 'None', 'Info', 'Warning' or 'Error'."
+      />
+    
+    <!-- 
+    Messages marked as `IsCritical` appear in Visual Studio's Error List under the 'Messages' tab. 
+    Note that the Message task does not support the `HelpLink` property. :(
+    -->
+    <Message
+      Condition="'$(IsExtensibilityEssentialsMissing)' == 'true' and '$(ExtensibilityEssentialsLevel)' == 'Info'"
+      Text="$(ExtensibilityEssentialsInfoText)"
+      Code="$(ExtensibilityEssentialsCode)"
+      IsCritical="true"
+      />
+    
+    <!-- For MSBuild versions that do not support `HelpLink`. -->
+    <Warning 
+      Condition="'$(WarningsAndErrorsHaveHelpLink)' != 'true' and '$(IsExtensibilityEssentialsMissing)' == 'true' and '$(ExtensibilityEssentialsLevel)' == 'Warning'" 
+      Text="$(ExtensibilityEssentialsWarningText)" 
+      Code="$(ExtensibilityEssentialsCode)"
+      />
+
+    <Error 
+      Condition="'$(WarningsAndErrorsHaveHelpLink)' != 'true' and '$(IsExtensibilityEssentialsMissing)' == 'true' and '$(ExtensibilityEssentialsLevel)' == 'Error'" 
+      Text="$(ExtensibilityEssentialsErrorText)" 
+      Code="$(ExtensibilityEssentialsCode)"
+      />
+      
+    <!-- For MSBuild versions that support `HelpLink`. -->
+    <Warning 
+      Condition="'$(WarningsAndErrorsHaveHelpLink)' == 'true' and '$(IsExtensibilityEssentialsMissing)' == 'true' and '$(ExtensibilityEssentialsLevel)' == 'Warning'" 
+      Text="$(ExtensibilityEssentialsWarningText)" 
+      Code="$(ExtensibilityEssentialsCode)"
+      HelpLink="$(ExtensibilityEssentialsHelpLink)"
+      />
+
+    <Error 
+      Condition="'$(WarningsAndErrorsHaveHelpLink)' == 'true' and '$(IsExtensibilityEssentialsMissing)' == 'true' and '$(ExtensibilityEssentialsLevel)' == 'Error'" 
+      Text="$(ExtensibilityEssentialsErrorText)" 
+      Code="$(ExtensibilityEssentialsCode)"
+      HelpLink="$(ExtensibilityEssentialsHelpLink)"
+      />
+  </Target>
+
+</Project>

--- a/src/DependencyInjection/Microsoft/DependencyInjection.Microsoft.Common.props
+++ b/src/DependencyInjection/Microsoft/DependencyInjection.Microsoft.Common.props
@@ -1,0 +1,52 @@
+<Project>
+
+  <PropertyGroup>
+    <Authors>VSIX Community</Authors>
+    <Owners>VSIX Community</Owners>
+    <Copyright>© Mads Kristensen. All rights reserved.</Copyright>
+    <PackageProjectUrl>https://github.com/VsixCommunity/Community.VisualStudio.Toolkit</PackageProjectUrl>
+    <RepositoryUrl>$(PackageProjectUrl)</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <DebugType>embedded</DebugType>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugType>portable</DebugType>
+    
+    <PackageId>Community.VisualStudio.Toolkit.DependencyInjection.Microsoft</PackageId>
+    <AssemblyName>Community.VisualStudio.Toolkit.DependencyInjection.Microsoft</AssemblyName>
+    <PackageDescription>Adds a Microsoft implementation of dependency injection to the Community.VisualStudio.Toolkit</PackageDescription>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageIcon>Icon.png</PackageIcon>
+    <PackageTags>VisualStudio, VSSDK, SDK</PackageTags>
+    <RootNamespace>Community.VisualStudio.Toolkit.DependencyInjection.Microsoft</RootNamespace>
+
+    <LangVersion>9</LangVersion>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>../../../key.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\..\Icon.png" Link="Icon.png" Pack="true" PackagePath="" Visible="false" />
+    <None Include="../Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.props" Pack="true" PackagePath="build" Visible="false" />
+    <None Include="../Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.targets" Pack="true" PackagePath="build" Visible="false" />
+    <None Include="../AssemblyInfo.cs" Pack="true" PackagePath="build" Visible="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System.Design" />
+    <Reference Include="System.Windows" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)Shared\Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.Shared.projitems" Label="Shared" />
+
+</Project>

--- a/src/DependencyInjection/Microsoft/Shared/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.Shared.projitems
+++ b/src/DependencyInjection/Microsoft/Shared/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.Shared.projitems
@@ -9,5 +9,6 @@
     <Import_RootNamespace>Community.VisualStudio.Toolkit.DependencyInjection.Microsoft</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)MicrosoftDIToolkitPackage.cs" />
   </ItemGroup>
 </Project>

--- a/src/DependencyInjection/Microsoft/Shared/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.Shared.projitems
+++ b/src/DependencyInjection/Microsoft/Shared/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.Shared.projitems
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>249f45ff-16e4-417b-99fa-686d20ed42c2</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>Community.VisualStudio.Toolkit.DependencyInjection.Microsoft</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+  </ItemGroup>
+</Project>

--- a/src/DependencyInjection/Microsoft/Shared/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.Shared.shproj
+++ b/src/DependencyInjection/Microsoft/Shared/Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.Shared.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>249f45ff-16e4-417b-99fa-686d20ed42c2</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/src/DependencyInjection/Microsoft/Shared/MicrosoftDIToolkitPackage.cs
+++ b/src/DependencyInjection/Microsoft/Shared/MicrosoftDIToolkitPackage.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.Shell;
+
+namespace Community.VisualStudio.Toolkit.DependencyInjection.Microsoft
+{
+    /// <summary>
+    /// Package with a Microsoft dependency injection implementation.
+    /// </summary>
+    /// <typeparam name="TPackage"></typeparam>
+    public class MicrosoftDIToolkitPackage<TPackage> : DIToolkitPackage<TPackage>
+        where TPackage : AsyncPackage
+    {
+        /// <inheritdoc/>
+        protected override IServiceProvider BuildServiceProvider(IServiceCollection serviceCollection)
+        {
+            if (!(serviceCollection is ServiceCollection services))
+                throw new Exception($"The '{nameof(IServiceCollection)}' must be of type '{typeof(ServiceCollection).FullName}'.");
+
+            return services.BuildServiceProvider();
+        }
+
+        /// <inheritdoc/>
+        protected override IServiceCollection CreateServiceCollection()
+        {
+            return new ServiceCollection();
+        }
+    }
+}

--- a/test/VSSDK.TestExtension/Commands/DependencyInjectionCommand.cs
+++ b/test/VSSDK.TestExtension/Commands/DependencyInjectionCommand.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using Community.VisualStudio.Toolkit;
+using Community.VisualStudio.Toolkit.DependencyInjection.Core;
+using Microsoft.VisualStudio.Shell;
+using VSSDK.TestExtension;
+
+namespace TestExtension.Commands
+{
+    [Command(PackageIds.TestDependencyInjection)]
+    internal sealed class DependencyInjectionCommand : BaseCommand<DependencyInjectionCommand>
+    {
+        protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            IToolkitServiceProvider<TestExtensionPackage> serviceProvider = await VS.GetServiceAsync<SToolkitServiceProvider<TestExtensionPackage>, IToolkitServiceProvider<TestExtensionPackage>>();
+
+            if (serviceProvider == null)
+                await VS.MessageBox.ShowErrorAsync($"There was an error trying to retrieve the {nameof(IToolkitServiceProvider<TestExtensionPackage>)}.");
+            else
+                await VS.MessageBox.ShowAsync($"The {nameof(IToolkitServiceProvider<TestExtensionPackage>)} was retrieved from the service collection succuessfully!");
+        }
+    }
+}

--- a/test/VSSDK.TestExtension/TestExtensionPackage.cs
+++ b/test/VSSDK.TestExtension/TestExtensionPackage.cs
@@ -2,6 +2,7 @@
 using System.Runtime.InteropServices;
 using System.Threading;
 using Community.VisualStudio.Toolkit;
+using Community.VisualStudio.Toolkit.DependencyInjection.Microsoft;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using TestExtension;
@@ -20,10 +21,12 @@ namespace VSSDK.TestExtension
     [ProvideFileIcon(".abc", "KnownMonikers.Reference")]
     [ProvideToolWindow(typeof(MultiInstanceWindow.Pane))]
     [ProvideMenuResource("Menus.ctmenu", 1)]
-    public sealed class TestExtensionPackage : ToolkitPackage
+    public sealed class TestExtensionPackage : MicrosoftDIToolkitPackage<TestExtensionPackage>
     {
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
+            await base.InitializeAsync(cancellationToken, progress);
+
             // Tool windows
             RunnerWindow.Initialize(this);
             ThemeWindow.Initialize(this);
@@ -37,6 +40,7 @@ namespace VSSDK.TestExtension
             await MultiInstanceWindowCommand.InitializeAsync(this);
             await BuildActiveProjectAsyncCommand.InitializeAsync(this);
             await BuildSolutionAsyncCommand.InitializeAsync(this);
+            await DependencyInjectionCommand.InitializeAsync(this);
         }
     }
 }

--- a/test/VSSDK.TestExtension/VSCommandTable.cs
+++ b/test/VSSDK.TestExtension/VSCommandTable.cs
@@ -27,5 +27,6 @@ namespace TestExtension
         public const int MultiInstanceWindow = 0x0102;
         public const int BuildActiveProjectAsync = 0x0103;
         public const int BuildSolutionAsync = 0x0104;
+        public const int TestDependencyInjection = 0x0105;
     }
 }

--- a/test/VSSDK.TestExtension/VSCommandTable.vsct
+++ b/test/VSSDK.TestExtension/VSCommandTable.vsct
@@ -5,7 +5,7 @@
   <Extern href="vsshlids.h"/>
   <Include href="KnownImageIds.vsct"/>
   <Include href="VSGlobals.vsct"/>
-  
+
   <Commands package="TestExtension">
     <!--This section defines the elements the user can interact with, like a menu command or a button
         or combo box in a toolbar. -->
@@ -18,13 +18,13 @@
         </Strings>
       </Menu>
     </Menus>
-    
+
     <Groups>
       <Group guid="TestExtension" id="TestExtensionMainMenuGroup1" priority="0x1100">
         <Parent guid="TestExtension" id="TestExtensionMainMenu" />
       </Group>
     </Groups>
-    
+
     <Buttons>
       <Button guid="TestExtension" id="RunnerWindow" priority="0x0105" type="Button">
         <Parent guid="VSMainMenu" id="View.DevWindowsGroup.OtherWindows.Group1"/>
@@ -70,6 +70,15 @@
           <ButtonText>Build Solution Async</ButtonText>
         </Strings>
       </Button>
+
+      <Button guid="TestExtension" id="TestDependencyInjection" priority="0x0102" type="Button">
+        <Parent guid="TestExtension" id="TestExtensionMainMenuGroup1"/>
+        <Icon guid="ImageCatalogGuid" id="BuildSolution" />
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <Strings>
+          <ButtonText>Test Dependency Injection Functionality</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
   </Commands>
 
@@ -77,12 +86,13 @@
     <GuidSymbol name="TestExtension" value="{05271709-8845-42fb-9d10-621cc8cffc5d}">
       <IDSymbol name="TestExtensionMainMenu" value="0x1000" />
       <IDSymbol name="TestExtensionMainMenuGroup1" value="0x1100" />
-      
+
       <IDSymbol name="RunnerWindow" value="0x0100" />
       <IDSymbol name="ThemeWindow" value="0x0101" />
       <IDSymbol name="MultiInstanceWindow" value="0x0102" />
       <IDSymbol name="BuildActiveProjectAsync" value="0x0103" />
       <IDSymbol name="BuildSolutionAsync" value="0x0104" />
+      <IDSymbol name="TestDependencyInjection" value="0x0105" />
     </GuidSymbol>
   </Symbols>
 </CommandTable>

--- a/test/VSSDK.TestExtension/VSSDK.TestExtension.csproj
+++ b/test/VSSDK.TestExtension/VSSDK.TestExtension.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <Compile Include="Commands\BuildActiveProjectAsyncCommand.cs" />
     <Compile Include="Commands\BuildSolutionAsyncCommand.cs" />
+    <Compile Include="Commands\DependencyInjectionCommand.cs" />
     <Compile Include="Commands\MultiInstanceWindowCommand.cs" />
     <Compile Include="Commands\RunnerWindowCommand.cs" />
     <Compile Include="Commands\ThemeWindowCommand.cs" />
@@ -146,6 +147,14 @@
     <ProjectReference Include="..\..\src\Community.VisualStudio.Toolkit.17.0\Community.VisualStudio.Toolkit.17.0.csproj">
       <Project>{d000c76d-4d0f-48f9-b5ab-5696c92cc7bd}</Project>
       <Name>Community.VisualStudio.Toolkit.17.0</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\DependencyInjection\Core\17.0\Community.VisualStudio.Toolkit.DependencyInjection.Core.17.0.csproj">
+      <Project>{46f70315-990a-43dc-a28b-f61672050d7d}</Project>
+      <Name>Community.VisualStudio.Toolkit.DependencyInjection.Core.17.0</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\DependencyInjection\Microsoft\17.0\Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.17.0.csproj">
+      <Project>{c54ad939-b3b3-4234-b3d0-4929e32b7b72}</Project>
+      <Name>Community.VisualStudio.Toolkit.DependencyInjection.Microsoft.17.0</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
In relation to #122. Previous PR with discussions: #123

This adds several new projects that will produce the following 2 packages:
1) `Community.VisualStudio.Toolkit.DependencyInjection.Core`
2) `Community.VisualStudio.Toolkit.DependencyInjection.Microsoft`

Project structure now looks like:
![image](https://user-images.githubusercontent.com/11198735/125986169-247981f7-232a-4a59-b894-e6aae7d72300.png)
