### PR TITLE
BaseOptionModel serializes to the closest data type by default (#112)

### DIFF
--- a/Community.VisualStudio.Toolkit.sln
+++ b/Community.VisualStudio.Toolkit.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31321.278
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31512.422
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Community.VisualStudio.Toolkit.16.0", "src\Community.VisualStudio.Toolkit.16.0\Community.VisualStudio.Toolkit.16.0.csproj", "{38DC82EA-91D6-4360-B76C-995708EE43A3}"
 EndProject
@@ -26,8 +26,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Community.VisualStudio.Tool
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Community.VisualStudio.Toolkit.17.0", "src\Community.VisualStudio.Toolkit.17.0\Community.VisualStudio.Toolkit.17.0.csproj", "{D000C76D-4D0F-48F9-B5AB-5696C92CC7BD}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Community.VisualStudio.Toolkit.UnitTests", "src\Community.VisualStudio.Toolkit.UnitTests\Community.VisualStudio.Toolkit.UnitTests.csproj", "{39738FD8-2E70-4B0F-BD16-4B034FEB5B2E}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		src\Community.VisualStudio.Toolkit.Shared\VSSDK.Helpers.Shared.projitems*{39738fd8-2e70-4b0f-bd16-4b034feb5b2e}*SharedItemsImports = 5
 		src\Community.VisualStudio.Toolkit.Shared\VSSDK.Helpers.Shared.projitems*{5ec463ac-24cb-443e-9ff9-91b7ecb1f822}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -55,6 +58,10 @@ Global
 		{D000C76D-4D0F-48F9-B5AB-5696C92CC7BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D000C76D-4D0F-48F9-B5AB-5696C92CC7BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D000C76D-4D0F-48F9-B5AB-5696C92CC7BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{39738FD8-2E70-4B0F-BD16-4B034FEB5B2E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{39738FD8-2E70-4B0F-BD16-4B034FEB5B2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{39738FD8-2E70-4B0F-BD16-4B034FEB5B2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{39738FD8-2E70-4B0F-BD16-4B034FEB5B2E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Community.VisualStudio.Toolkit.Shared/Options/IOptionModelPropertyWrapper.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Options/IOptionModelPropertyWrapper.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.VisualStudio.Settings;
+
+namespace Community.VisualStudio.Toolkit
+{
+    /// <summary>   Implementation should wrap an instance property member with public getter and setters from a <see cref="BaseOptionModel{T}"/>,
+    ///             and expose the ability to load and save the value of the property to the <see cref="SettingsStore"/>.
+    /// </summary>
+    public interface IOptionModelPropertyWrapper
+    {
+        /// <summary>   If the setting is found in the <paramref name="settingsStore"/>, retrieves the value of the setting, 
+        ///             converts or deserializes it to the type of the wrapped property, and calls the property set method on 
+        ///             the <paramref name="baseOptionModel"/>. No exceptions should be thrown from
+        ///             this method. No changes to the property will be made if the setting does not exist. </summary>
+        /// <typeparam name="TOptMdl">  Type of the base option model. </typeparam>
+        /// <param name="baseOptionModel">  The base option model which is used as the target object on which the property 
+        ///                                 will be set. It also can be used for deserialization of stored data.  </param>
+        /// <param name="settingsStore">    The settings store to retrieve the setting value from. </param>
+        /// <returns>   True if the value exists in the <paramref name="settingsStore"/>, and the property was updated in
+        ///             <paramref name="baseOptionModel"/>, false if setting does not exist or any step of the process 
+        ///             failed. </returns>
+        bool Load<TOptMdl>(BaseOptionModel<TOptMdl> baseOptionModel, SettingsStore settingsStore) where TOptMdl : BaseOptionModel<TOptMdl>, new();
+
+        /// <summary>   The value of the wrapped property is retrieved by calling the property get method on <paramref name="baseOptionModel"/>.
+        ///             This value is converted or serialized to a native type supported by the <paramref name="settingsStore"/>, 
+        ///             then persisted to the store, assuring the collection exists first. No exceptions should be thrown from
+        ///             this method. </summary>
+        /// <typeparam name="TOptMdl">  Type of the base option model. </typeparam>
+        /// <param name="baseOptionModel">  The base option model which is used as the target object from which the property 
+        ///                                 value will be retrieved. It also can be used for serialization of stored data.  </param>
+        /// <param name="settingsStore">    The settings store to set the setting value in. </param>
+        /// <returns>   True if we were able to persist the value in the store. However, if the serialization results in a null value,
+        ///             it cannot be persisted in the settings store and false will be returned. False is also returned if any step 
+        ///             of the process failed, and these are logged. </returns>
+        bool Save<TOptMdl>(BaseOptionModel<TOptMdl> baseOptionModel, WritableSettingsStore settingsStore) where TOptMdl : BaseOptionModel<TOptMdl>, new();
+    }
+}

--- a/src/Community.VisualStudio.Toolkit.Shared/Options/NativeSettingsType.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Options/NativeSettingsType.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.IO;
+using Microsoft.VisualStudio.Settings;
+
+namespace Community.VisualStudio.Toolkit
+{
+    /// <summary>
+    /// Data types of the properties that are stored inside the collections. This mostly mirror
+    /// <see cref="SettingsType"/>, but adds <c>UInt32</c> and <c>UInt64</c>
+    /// </summary>
+    public enum NativeSettingsType
+    {
+        /// <summary>
+        /// Data type used to store 4 byte (32 bits) properties which are Boolean and Int32. Note
+        /// that Boolean is stored 1 byte in the .NET environment but as a property inside the SettingsStore,
+        /// it is kept as 4 byte value and any value other than 0 is converted to true and 0 is converted to
+        /// false.
+        /// NOTE: In .NET we need to explicitly use the unsigned methods to successfully store unsigned types.
+        /// This enumeration adds <see cref="UInt32"/> for that purpose.
+        /// </summary>
+        Int32 = 1,
+        /// <summary>
+        /// Data type used to store 8 byte (64 bit) properties which are Int64.
+        /// NOTE: In .NET we need to explicitly use the unsigned methods to successfully store unsigned types. 
+        /// This enumeration adds <see cref="UInt64"/> for that purpose.
+        /// </summary>
+        Int64 = 2,
+        /// <summary>Data type used to store the strings.</summary>
+        String = 3,
+        /// <summary>Data type used to store byte streams (arrays).</summary>
+        Binary = 4,
+        /// <summary>
+        /// Data type used to store 4 byte (32 bits) properties which is UInt32.
+        /// NOTE: This value is not in <see cref="SettingsType"/>, but is necessary so we can use the 
+        /// appropriate methods to successfully store unsigned types.
+        /// </summary>
+        UInt32 = 5,
+        /// <summary>
+        /// Data type used to store 8 byte (64 bit) properties which is UInt64.
+        /// NOTE: This value is not in <see cref="SettingsType"/>, but is necessary so we can use the 
+        /// appropriate methods to successfully store unsigned types.
+        /// </summary>
+        UInt64 = 6,
+    }
+
+    /// <summary>   Extension methods for <see cref="NativeSettingsType"/>. </summary>
+    public static class NativeSettingsTypeExtensions
+    {
+        /// <summary>   Get the .NET <see cref="Type"/> based on the method signature for the <see cref="SettingsStore"/>
+        ///             necessary to retrieve and store data. </summary>
+        /// <exception cref="ArgumentOutOfRangeException">  Thrown when one or more arguments are outside
+        ///                                                 the required range. </exception>
+        /// <param name="nativeSettingsType">   The nativeSettingsType to act on. </param>
+        /// <returns>   The .NET <see cref="Type"/>. Not Null. </returns>
+        public static Type GetDotNetType(this NativeSettingsType nativeSettingsType)
+        {
+            switch (nativeSettingsType)
+            {
+                case NativeSettingsType.Int32:
+                    return typeof(int);
+                case NativeSettingsType.Int64:
+                    return typeof(long);
+                case NativeSettingsType.String:
+                    return typeof(string);
+                case NativeSettingsType.Binary:
+                    return typeof(MemoryStream);
+                case NativeSettingsType.UInt32:
+                    return typeof(uint);
+                case NativeSettingsType.UInt64:
+                    return typeof(ulong);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(nativeSettingsType), nativeSettingsType, null);
+            }
+        }
+    }
+}

--- a/src/Community.VisualStudio.Toolkit.Shared/Options/OptionModelPropertyWrapper.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Options/OptionModelPropertyWrapper.cs
@@ -1,0 +1,662 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Serialization.Formatters.Binary;
+using Microsoft.VisualStudio.Settings;
+using Microsoft.VisualStudio.Threading;
+
+namespace Community.VisualStudio.Toolkit
+{
+    /// <summary>   Wraps an instance property member with public getter and setters from a <see cref="BaseOptionModel{T}"/>,
+    ///             and exposes the ability to load and save the value of the property to the <see cref="SettingsStore"/>.
+    /// </summary>
+    /// <remarks>
+    ///             The instance of the <see cref="BaseOptionModel{T}"/> provides the default collection path that is used 
+    ///             to store the property values. Adding <see cref="OverrideCollectionNameAttribute"/> to the property will
+    ///             override this only for the attributed property. This also will infer the proper data type to store 
+    ///             the property value as for common types to avoid serialization. See remarks at
+    ///             <see cref="ConvertPropertyTypeToStorageType{T}"/> for specifics.
+    ///             <para/> 
+    ///             For types not supported by default, the overridable serialization methods in <see cref="BaseOptionModel{T}"/> 
+    ///             will be used, and the output of that will be stored. Alternatively, you can apply the <see cref="OverrideDataTypeAttribute"/>
+    ///             specifying the storage type/methodology. By default, that will use <see cref="Convert.ChangeType(object,Type, IFormatProvider)"/> 
+    ///             with <see cref="CultureInfo.InvariantCulture"/>, though that attribute can also include a flag to use the type's 
+    ///             <see cref="System.ComponentModel.TypeConverterAttribute"/> instead.
+    ///             <para/>
+    ///             The implementation of this class uses reflection, only in the ctor, to create an open delegate that is used
+    ///             to get and set the property values. This initial hit using reflection happens once, and subsequent load
+    ///             and saves of the value are therefore as performant as possible. This is the technique used by
+    ///             <a href="https://codeblog.jonskeet.uk/2008/08/09/making-reflection-fly-and-exploring-delegates/">Jon Skeet
+    ///             in Google's Protocol Buffers</a>.
+    /// </remarks>
+    public class OptionModelPropertyWrapper : IOptionModelPropertyWrapper
+    {
+        #region Static Initialization
+
+        /// <summary>   (Immutable) Dictionary of types, limited to the types available in <see cref="SettingsStore"/>, to a
+        ///             delegate with a signature of <c>WritableSettingsStore targetSettingsStore, string collectionPath,
+        ///             string propertyPath, object value</c>. This is initialized in the static ctor. </summary>
+        protected static IReadOnlyDictionary<NativeSettingsType, Action<WritableSettingsStore, string, string, object>> SettingStoreSetMethodsDict { get; }
+
+        /// <summary>   (Immutable) Dictionary of types, limited to the types available in <see cref="SettingsStore"/>, to a 
+        ///             delegate with a signature of <c>SettingsStore targetSettingsStore, string collectionPath,
+        ///             string propertyPath</c>, which returns the value of the setting as an object. This is initialized 
+        ///             in the static ctor. </summary>
+        protected static IReadOnlyDictionary<NativeSettingsType, Func<SettingsStore, string, string, object>> SettingStoreGetMethodsDict { get; }
+
+        /// <summary>   One-time static initialization of delegates to interact with the <see cref="SettingsStore"/> and <see cref="WritableSettingsStore"/>. </summary>
+        static OptionModelPropertyWrapper()
+        {
+            Dictionary<NativeSettingsType, Action<WritableSettingsStore, string, string, object>> settingStoreSetMethodsDict = new(7);
+            SettingStoreSetMethodsDict = settingStoreSetMethodsDict;
+
+            Dictionary<NativeSettingsType, Func<SettingsStore, string, string, object>> settingStoreGetMethodsDict = new(7);
+            SettingStoreGetMethodsDict = settingStoreGetMethodsDict;
+
+            Type typeOfWritableSettingsStore = typeof(WritableSettingsStore);
+            settingStoreSetMethodsDict[NativeSettingsType.String] = CreateSettingsStoreSetMethod<string>(typeOfWritableSettingsStore.GetMethod(nameof(WritableSettingsStore.SetString), new[] { typeof(string), typeof(string), typeof(string) }));
+            settingStoreSetMethodsDict[NativeSettingsType.Int32] = CreateSettingsStoreSetMethod<int>(typeOfWritableSettingsStore.GetMethod(nameof(WritableSettingsStore.SetInt32), new[] { typeof(string), typeof(string), typeof(int) }));
+            settingStoreSetMethodsDict[NativeSettingsType.UInt32] = CreateSettingsStoreSetMethod<uint>(typeOfWritableSettingsStore.GetMethod(nameof(WritableSettingsStore.SetUInt32), new[] { typeof(string), typeof(string), typeof(uint) }));
+            settingStoreSetMethodsDict[NativeSettingsType.Int64] = CreateSettingsStoreSetMethod<long>(typeOfWritableSettingsStore.GetMethod(nameof(WritableSettingsStore.SetInt64), new[] { typeof(string), typeof(string), typeof(long) }));
+            settingStoreSetMethodsDict[NativeSettingsType.UInt64] = CreateSettingsStoreSetMethod<ulong>(typeOfWritableSettingsStore.GetMethod(nameof(WritableSettingsStore.SetUInt64), new[] { typeof(string), typeof(string), typeof(ulong) }));
+            settingStoreSetMethodsDict[NativeSettingsType.Binary] = CreateSettingsStoreSetMethod<System.IO.MemoryStream>(typeOfWritableSettingsStore.GetMethod(nameof(WritableSettingsStore.SetMemoryStream), new[] { typeof(string), typeof(string), typeof(System.IO.MemoryStream) }));
+
+            Type typeOfSettingsStore = typeof(SettingsStore);
+            settingStoreGetMethodsDict[NativeSettingsType.String] = CreateSettingsStoreGetMethod<string>(typeOfSettingsStore.GetMethod(nameof(SettingsStore.GetString), new[] { typeof(string), typeof(string) }));
+            settingStoreGetMethodsDict[NativeSettingsType.Int32] = CreateSettingsStoreGetMethod<int>(typeOfSettingsStore.GetMethod(nameof(SettingsStore.GetInt32), new[] { typeof(string), typeof(string) }));
+            settingStoreGetMethodsDict[NativeSettingsType.UInt32] = CreateSettingsStoreGetMethod<uint>(typeOfSettingsStore.GetMethod(nameof(SettingsStore.GetUInt32), new[] { typeof(string), typeof(string) }));
+            settingStoreGetMethodsDict[NativeSettingsType.Int64] = CreateSettingsStoreGetMethod<long>(typeOfSettingsStore.GetMethod(nameof(SettingsStore.GetInt64), new[] { typeof(string), typeof(string) }));
+            settingStoreGetMethodsDict[NativeSettingsType.UInt64] = CreateSettingsStoreGetMethod<ulong>(typeOfSettingsStore.GetMethod(nameof(SettingsStore.GetUInt64), new[] { typeof(string), typeof(string) }));
+            settingStoreGetMethodsDict[NativeSettingsType.Binary] = CreateSettingsStoreGetMethod<System.IO.MemoryStream>(typeOfSettingsStore.GetMethod(nameof(SettingsStore.GetMemoryStream), new[] { typeof(string), typeof(string) }));
+        }
+
+        /// <summary>   Creates a <c>delegate</c> to the settings store that sets a value in the settings store. The delegate
+        ///             exposes a common signature that intentionally makes the type to be set an <c>object</c> to simplify code. </summary>
+        /// <typeparam name="T">    The actual type being stored in the <see cref="WritableSettingsStore"/>. </typeparam>
+        /// <param name="mi">   The method info of the typed set method for the <see cref="WritableSettingsStore"/>. </param>
+        /// <returns>   The delegate to set a value, as described above. </returns>
+        private static Action<WritableSettingsStore, string, string, object> CreateSettingsStoreSetMethod<T>(MethodInfo mi)
+        {
+            Action<WritableSettingsStore, string, string, T> action = (Action<WritableSettingsStore, string, string, T>)Delegate.CreateDelegate(typeof(Action<WritableSettingsStore, string, string, T>), mi, true)!;
+            return delegate (WritableSettingsStore settingsStore, string collectionName, string propertyName, object value)
+            {
+                action(settingsStore, collectionName, propertyName, (T)value);
+            };
+        }
+
+        /// <summary>   Creates a <c>delegate</c> to the settings store that gets a value from the settings store. The delegate
+        ///             exposes a common signature that intentionally makes the return type an <c>object</c> to simplify code. </summary>
+        /// <typeparam name="T">    The actual type that is stored in the <see cref="SettingsStore"/>. </typeparam>
+        /// <param name="mi">   The method info of the typed get method for the <see cref="SettingsStore"/>. </param>
+        /// <returns>   The delegate to get a value, as described above. </returns>
+        private static Func<SettingsStore, string, string, object> CreateSettingsStoreGetMethod<T>(MethodInfo mi)
+        {
+            Func<SettingsStore, string, string, T> func = (Func<SettingsStore, string, string, T>)Delegate.CreateDelegate(typeof(Func<SettingsStore, string, string, T>), mi, true)!;
+            return (settingsStore, collectionName, propertyName) => func(settingsStore, collectionName, propertyName)!;
+        }
+
+        #endregion
+
+        #region Construction and initialization
+
+        /// <summary>   Initializes a new instance of the class. </summary>
+        /// <param name="propertyInfo"> The property being wrapped. </param>
+        public OptionModelPropertyWrapper(PropertyInfo propertyInfo)
+        {
+            PropertyInfo = propertyInfo;
+            PropertyName = propertyInfo.Name;
+            WrappedPropertySetMethod = CreateWrappedPropertySetDelegate(propertyInfo);
+            WrappedPropertyGetMethod = CreateWrappedPropertyGetDelegate(propertyInfo);
+
+            OverrideDataTypeAttribute? overrideDataTypeAttribute = null;
+            foreach (Attribute attribute in propertyInfo.GetCustomAttributes())
+            {
+                if (attribute is OverrideCollectionNameAttribute collectionNameAttribute)
+                {
+                    string collectionName = collectionNameAttribute.CollectionName.Trim();
+                    if (collectionName.Length > 0)
+                        OverrideCollectionName = collectionName;
+                }
+                else if (attribute is OverridePropertyNameAttribute overridePropertyNameAttribute)
+                {
+                    string propertyName = overridePropertyNameAttribute.PropertyName.Trim();
+                    if (propertyName.Length > 0)
+                        PropertyName = propertyName;
+                }
+                else if (attribute is OverrideDataTypeAttribute odt)
+                {
+                    overrideDataTypeAttribute = odt;
+                }
+            }
+
+            if (overrideDataTypeAttribute != null)
+            {
+                DataType = overrideDataTypeAttribute.SettingDataType;
+                if (overrideDataTypeAttribute.UseTypeConverter && DataType != SettingDataType.Legacy && DataType != SettingDataType.Serialized)
+                    TypeConverter = TypeDescriptor.GetConverter(propertyInfo.PropertyType);
+            }
+            else
+            {
+                DataType = InferDataType(propertyInfo.PropertyType);
+            }
+
+            NativeStorageType = GetNativeSettingsType(DataType);
+            SettingStoreSetMethod = SettingStoreSetMethodsDict[NativeStorageType];
+            SettingStoreGetMethod = SettingStoreGetMethodsDict[NativeStorageType];
+        }
+
+        /// <summary>   Creates a delegate that can get the value of a property with object signatures. This is
+        ///             for both performance reasons and ease of implementation as types are not known until runtime. </summary>
+        /// <param name="propertyInfo">   The property for which to create the delegate. </param>
+        /// <returns>   A delegate as described above. </returns>
+        protected static Func<object, object?> CreateWrappedPropertyGetDelegate(PropertyInfo propertyInfo)
+        {
+            // First fetch the generic form
+            MethodInfo? genericHelper = typeof(OptionModelPropertyWrapper).GetMethod(nameof(PropertyGetHelper), BindingFlags.Static | BindingFlags.NonPublic);
+            if (genericHelper == null)
+                throw new InvalidOperationException($"Could not get method {nameof(PropertyGetHelper)}");
+
+            // Now supply the type arguments
+            MethodInfo constructedHelper = genericHelper.MakeGenericMethod(propertyInfo.DeclaringType, propertyInfo.PropertyType);
+
+            // Now call it. The null argument is because it's a static method.
+            object ret = constructedHelper.Invoke(null, new object[] { propertyInfo.GetGetMethod(false) });
+
+            // Cast the result to the right kind of delegate and return it
+            return (Func<object, object?>)ret;
+        }
+
+        /// <summary>   Gets a delegate that ultimately will get value of a property. The real types are not known at compile-time,
+        ///             so this is called via reflection. The returned delegate has the signature using objects, which at runtime 
+        ///             are cast to the proper types. </summary>
+        /// <typeparam name="TTarget">  Type for the target object on which the property get method will be called. </typeparam>
+        /// <typeparam name="TReturn">  Type returned by the property get method. </typeparam>
+        /// <param name="method">   The property get method. </param>
+        /// <returns>   A delegate as described above. </returns>
+        private static Func<object, object?> PropertyGetHelper<TTarget, TReturn>(MethodInfo method)
+        {
+            // Convert the slow MethodInfo into a fast, strongly typed, open delegate
+            Func<TTarget, TReturn> func = (Func<TTarget, TReturn>)Delegate.CreateDelegate(typeof(Func<TTarget, TReturn>), method);
+
+            // Now create a more weakly typed delegate which will call the strongly typed one
+            return (object target) => func((TTarget)target);
+        }
+
+        /// <summary>   Creates a delegate that can set the value of a property with object signatures. This is
+        ///             for both performance reasons and ease of implementation as types are not known until runtime. </summary>
+        /// <param name="propertyInfo">   The property for which to create the delegate. </param>
+        /// <returns>   A delegate as described above. </returns>
+        protected static Action<object, object?> CreateWrappedPropertySetDelegate(PropertyInfo propertyInfo)
+        {
+            // First fetch the generic form
+            MethodInfo? genericHelper = typeof(OptionModelPropertyWrapper).GetMethod(nameof(PropertySetHelper), BindingFlags.Static | BindingFlags.NonPublic);
+            if (genericHelper == null)
+                throw new InvalidOperationException($"Could not get method {nameof(PropertySetHelper)}");
+
+            // Now supply the type arguments
+            MethodInfo constructedHelper = genericHelper.MakeGenericMethod(propertyInfo.DeclaringType, propertyInfo.PropertyType);
+
+            // Now call it. The null argument is because it's a static method.
+            object ret = constructedHelper.Invoke(null, new object[] { propertyInfo.GetSetMethod(false) });
+
+            // Cast the result to the right kind of delegate and return it
+            return (Action<object, object?>)ret;
+        }
+
+        /// <summary>   Gets a delegate that ultimately will set value of a property. The real types are not known at compile-time,
+        ///             so this is called via reflection. The returned delegate has the signature using objects, which at runtime 
+        ///             are cast to the proper types. </summary>
+        /// <typeparam name="TTarget">  Type for the target object on which the property set method will be called. </typeparam>
+        /// <typeparam name="TParam">  Type expected by the property set method. </typeparam>
+        /// <param name="method">   The property set method. </param>
+        /// <returns>   A delegate as described above. </returns>
+        private static Action<object, object?> PropertySetHelper<TTarget, TParam>(MethodInfo method)
+        {
+            // Convert the slow MethodInfo into a fast, strongly typed, open delegate
+            Action<TTarget, TParam?> action = (Action<TTarget, TParam?>)Delegate.CreateDelegate
+                (typeof(Action<TTarget, TParam?>), method);
+
+            // Now create a more weakly typed delegate which will call the strongly typed one
+            return (object target, object? value) => action((TTarget)target, (TParam?)value);
+        }
+
+        #endregion
+
+        /// <summary>   (Immutable) The property being wrapped. </summary>
+        public PropertyInfo PropertyInfo { get; }
+
+        /// <summary>   (Immutable) Either specified via <see cref="OverrideDataTypeAttribute"/> or inferred from the
+        ///             <see cref="System.Reflection.PropertyInfo.PropertyType"/> of the wrapped property in the 
+        ///             <see cref="InferDataType"/> method. This serves a dual purpose - it specifies how the 
+        ///             wrapped value is converted to the storage type as well as the native type that is stored. </summary>
+        protected SettingDataType DataType { get; }
+
+        /// <summary>   (Immutable) A delegate to the method to set a value in <see cref="WritableSettingsStore"/>.
+        ///             This delegate signature is <c>WritableSettingsStore settingsStore, string collectionPath, 
+        ///             string propertyPath, object value</c>. </summary>
+        protected Action<WritableSettingsStore, string, string, object> SettingStoreSetMethod { get; }
+
+        /// <summary>   (Immutable) A delegate to the method to get a value from the <see cref="SettingsStore"/>.
+        ///             This delegate signature is <c>SettingsStore settingsStore, string collectionPath, 
+        ///             string propertyPath</c> and returns the value stored as an object. </summary>
+        protected Func<SettingsStore, string, string, object> SettingStoreGetMethod { get; }
+
+        /// <summary>   (Immutable) A delegate to set the value of the wrapped property from the <see cref="BaseOptionModel{T}"/> instance.
+        ///             These are explicitly object types in the signature but must be of the proper types when they are called. The 
+        ///             signature is <c>BaseOptionModel{T} targetObject, object value</c>, where the type of <c>value</c> must be  
+        ///             assignable to the <see cref="System.Reflection.PropertyInfo.PropertyType"/> of the wrapped property. </summary>
+        protected Action<object, object?> WrappedPropertySetMethod { get; }
+
+        /// <summary>   (Immutable) A delegate to get the value of the wrapped property from the <see cref="BaseOptionModel{T}"/> instance.
+        ///             These are explicitly object types in the signature but must be of the proper types when they are called. The
+        ///             signature is <c>BaseOptionModel{T} targetObject</c>, where the type that is returned will be the
+        ///             <see cref="System.Reflection.PropertyInfo.PropertyType"/> of the wrapped property. </summary>
+        protected Func<object, object?> WrappedPropertyGetMethod { get; }
+
+        /// <summary>   (Immutable) If not null the <c>CollectionPath</c> the value of this property should be loaded/saved to,
+        ///             which is set via the optional <see cref="OverrideCollectionNameAttribute"/> on the property.
+        ///             If null, the <see cref="BaseOptionModel{T}.CollectionName"/> should be used instead. </summary>
+        protected string? OverrideCollectionName { get; }
+
+        /// <summary>   (Immutable) The <c>PropertyName</c> in the <see cref="SettingsStore"/> where the value of this property 
+        ///             is stored. By default, this is the actual name of the property that this instance wraps. This can be 
+        ///             overridden via the optional <see cref="OverridePropertyNameAttribute"/> on the property. </summary>
+        protected string PropertyName { get; }
+
+        /// <summary>   (Immutable) The data type the property will be stored as, which is limited to the types available
+        ///             in <see cref="SettingsStore"/>. Set via <see cref="GetNativeSettingsType"/>. See also the summary of 
+        ///             <see cref="DataType"/>. </summary>
+        protected NativeSettingsType NativeStorageType { get; }
+
+        /// <summary>   (Immutable) If <see cref="OverrideDataTypeAttribute"/> is applied, and the <see cref="PropertyInfo"/> 
+        ///             <c>PropertyType</c> has a <see cref="TypeConverterAttribute"/> applied that is compatible with its 
+        ///             declared storage data type, this <see cref="System.ComponentModel.TypeConverter"/> will be non-null and used to convert
+        ///             the property value to and from the <see cref="SettingsStore"/> <see cref="NativeStorageType"/>.</summary>
+        protected TypeConverter? TypeConverter { get; }
+
+        /// <summary> Serialize using <see cref="BinaryFormatter"/>, then convert to a base64 string for storage. Returning an 
+        ///           empty string represents a null object. </summary>
+        /// <param name="value">        The object that is to be serialized. Can Be Null. </param>
+        internal static string LegacySerializeValue(object? value)
+        {
+            if (value == null)
+                return string.Empty;
+            using (MemoryStream stream = new())
+            {
+                BinaryFormatter formatter = new();
+                formatter.Serialize(stream, value);
+                stream.Flush();
+                return Convert.ToBase64String(stream.ToArray());
+            }
+        }
+
+        /// <summary> Convert base64 encoded string, then deserialize using <see cref="BinaryFormatter"/>. </summary>
+        /// <param name="serializedString">        The base64 encoded string that was serialized by <see cref="BinaryFormatter"/>.
+        ///                                        An empty string represents a null object.</param>
+        /// <param name="conversionType">          The type to deserialize as.</param>
+        internal static object? LegacyDeserializeValue(string serializedString, Type conversionType)
+        {
+            if (serializedString.Length == 0)
+            {
+                if (conversionType.IsValueType)
+                    return Activator.CreateInstance(conversionType);
+                return null;
+            }
+            byte[] b = Convert.FromBase64String(serializedString);
+            using (MemoryStream stream = new(b))
+            {
+                BinaryFormatter formatter = new();
+                return formatter.Deserialize(stream);
+            }
+        }
+
+        /// <summary>   The value of the wrapped property is retrieved by calling the property get method on <paramref name="baseOptionModel"/>.
+        ///             This value is converted or serialized to a native type supported by the <paramref name="settingsStore"/>, 
+        ///             then persisted to the store, assuring the collection exists first. No exceptions should be thrown from
+        ///             this method. </summary>
+        /// <typeparam name="TOptMdl">  Type of the base option model. </typeparam>
+        /// <param name="baseOptionModel">  The base option model which is used as the target object from which the property 
+        ///                                 value will be retrieved. It also can be used for serialization of stored data.  </param>
+        /// <param name="settingsStore">    The settings store to set the setting value in. </param>
+        /// <returns>   True if we were able to persist the value in the store. However, if the serialization results in a null value,
+        ///             it cannot be persisted in the settings store and false will be returned. False is also returned if any step 
+        ///             of the process failed, and these are logged. </returns>
+        public virtual bool Save<TOptMdl>(BaseOptionModel<TOptMdl> baseOptionModel, WritableSettingsStore settingsStore) where TOptMdl : BaseOptionModel<TOptMdl>, new()
+        {
+            string collectionName = OverrideCollectionName ?? baseOptionModel.CollectionName;
+            object? value = null;
+            try
+            {
+                value = WrappedPropertyGetMethod(baseOptionModel);
+
+                value = ConvertPropertyTypeToStorageType(value, baseOptionModel);
+
+                if (value == null)
+                {
+                    Exception ex = new("Cannot store null in settings store.");
+                    ex.LogAsync("BaseOptionModel<{0}>.{1} CollectionName:{2} PropertyName:{3} dataType:{4} PropertyType:{5} Value:{6}",
+                        baseOptionModel.GetType().FullName, nameof(Load), collectionName, PropertyName, DataType, PropertyInfo.PropertyType,
+                        value ?? "[NULL]").Forget();
+                    return false;
+                }
+
+                // Rather than if ! CollectionExists then CreateCollection this is likely more efficient.
+                settingsStore.CreateCollection(collectionName);
+                SettingStoreSetMethod(settingsStore, collectionName, PropertyName, value);
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                ex.Log("BaseOptionModel<{0}>.{1} CollectionName:{2} PropertyName:{3} dataType:{4} PropertyType:{5} Value:{6}",
+                    baseOptionModel.GetType().FullName, nameof(Load), collectionName, PropertyName, DataType, PropertyInfo.PropertyType,
+                    value ?? "[NULL]");
+            }
+
+            return false;
+        }
+
+        /// <summary>   If the setting is found in the <paramref name="settingsStore"/>, retrieves the value of the setting, 
+        ///             converts or deserializes it to the type of the wrapped property, and calls the property set method on 
+        ///             the <paramref name="baseOptionModel"/>. No exceptions should be thrown from
+        ///             this method. No changes to the property will be made if the setting does not exist. </summary>
+        /// <typeparam name="TOptMdl">  Type of the base option model. </typeparam>
+        /// <param name="baseOptionModel">  The base option model which is used as the target object on which the property 
+        ///                                 will be set. It also can be used for deserialization of stored data.  </param>
+        /// <param name="settingsStore">    The settings store to retrieve the setting value from. </param>
+        /// <returns>   True if the value exists in the <paramref name="settingsStore"/>, and the property was updated in
+        ///             <paramref name="baseOptionModel"/>, false if setting does not exist or any step of the process 
+        ///             failed. </returns>
+        public virtual bool Load<TOptMdl>(BaseOptionModel<TOptMdl> baseOptionModel, SettingsStore settingsStore) where TOptMdl : BaseOptionModel<TOptMdl>, new()
+        {
+            string collectionName = OverrideCollectionName ?? baseOptionModel.CollectionName;
+
+            object? value = null;
+            try
+            {
+                if (!settingsStore.PropertyExists(collectionName, PropertyName))
+                    return false;
+
+                value = SettingStoreGetMethod(settingsStore, collectionName, PropertyName);
+                value = ConvertStorageTypeToPropertyType(value, baseOptionModel);
+                WrappedPropertySetMethod(baseOptionModel, value);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                ex.Log("BaseOptionModel<{0}>.{1} CollectionName:{2} PropertyName:{3} dataType:{4} PropertyType:{5} Value:{6}",
+                    baseOptionModel.GetType().FullName, nameof(Load), collectionName, PropertyName, DataType, PropertyInfo.PropertyType,
+                    value ?? "[NULL]");
+            }
+
+            return false;
+        }
+
+        #region Type inference and conversion
+
+        /// <summary>   Gets the native data type that the property value will be stored as in the <see cref="SettingsStore"/>. </summary>
+        /// <param name="settingDataType">  The type/mechanism by which the value will be converted for storage. </param>
+        /// <returns>   The native data type that the property value will be stored as in the <see cref="SettingsStore"/>. </returns>
+        protected virtual NativeSettingsType GetNativeSettingsType(SettingDataType settingDataType)
+        {
+            switch (settingDataType)
+            {
+                case SettingDataType.Legacy:
+                case SettingDataType.String:
+                case SettingDataType.Serialized:
+                    return NativeSettingsType.String;
+                case SettingDataType.Int32:
+                    return NativeSettingsType.Int32;
+                case SettingDataType.UInt32:
+                    return NativeSettingsType.UInt32;
+                case SettingDataType.Int64:
+                    return NativeSettingsType.Int64;
+                case SettingDataType.UInt64:
+                    return NativeSettingsType.UInt64;
+                case SettingDataType.Binary:
+                    return NativeSettingsType.Binary;
+                default:
+                    throw new InvalidOperationException($"GetNativeDataType for SettingDataType {settingDataType} is not supported.");
+            }
+        }
+
+        /// <summary>   Infers the underlying type (or mechanism for unknown types) by which we will set the native data type. See remarks at 
+        /// <see cref="ConvertPropertyTypeToStorageType{T}"/> </summary>
+        /// <param name="propertyType">   The type of the property being wrapped. </param>
+        /// <returns>   A SettingDataType. </returns>
+        protected virtual SettingDataType InferDataType(Type propertyType)
+        {
+            // Enums can be any integral type, so if we are an enum, get the integral type and use that.
+            if (propertyType.IsEnum)
+                propertyType = propertyType.GetEnumUnderlyingType();
+
+            if (propertyType == typeof(string) || propertyType == typeof(float) || propertyType == typeof(double) ||
+                propertyType == typeof(decimal) || propertyType == typeof(char) || propertyType == typeof(Guid) ||
+                propertyType == typeof(DateTimeOffset))
+                return SettingDataType.String;
+            if (propertyType == typeof(bool) || propertyType == typeof(sbyte) || propertyType == typeof(byte) ||
+                propertyType == typeof(short) || propertyType == typeof(ushort) ||
+                propertyType == typeof(int) || propertyType == typeof(Color))
+                return SettingDataType.Int32;
+            if (propertyType == typeof(uint))
+                return SettingDataType.UInt32;
+            if (propertyType == typeof(long) || propertyType == typeof(DateTime))
+                return SettingDataType.Int64;
+            if (propertyType == typeof(ulong))
+                return SettingDataType.UInt64;
+            if (propertyType == typeof(byte[]) || propertyType == typeof(MemoryStream))
+                return SettingDataType.Binary;
+
+            // Use the serializer from BaseOptionModel for types unknown to us.
+            return SettingDataType.Serialized;
+        }
+
+        /// <summary>   Convert the <paramref name="propertyValue"/> retrieved from the property to the type it will be stored as in the
+        ///             <see cref="SettingsStore"/>. </summary>
+        /// <typeparam name="TOptMdl">  Type of <see cref="BaseOptionModel{TOptMdl}"/>. </typeparam>
+        /// <param name="propertyValue">        The value retrieved from the wrapped property, as an object. </param>
+        /// <param name="baseOptionModel">      Instance of <see cref="BaseOptionModel{TOptMdl}"/>. For types requiring serialization, methods in this object are used. </param>
+        /// <returns>   <paramref name="propertyValue"/>, converted to one of the types supported by <see cref="SettingsStore"/>. </returns>
+        /// <remarks>
+        /// The methods <see cref="ConvertPropertyTypeToStorageType{T}" />, <see cref="ConvertStorageTypeToPropertyType{T}" />, and <see cref="InferDataType"/> are designed to
+        /// work in tandem, and are therefore tightly coupled. The <see cref="SettingsStore"/> cannot store null values, therefore any property that is converted 
+        /// to a reference type cannot round-trip successfully if that conversion yields <see cref="string"/>, <see cref="MemoryStream"/>, and arrays of 
+        /// <see cref="byte"/> - in these cases the equivalent of <c>empty</c> is stored, therefore when loaded the result will not match.
+        /// <para />
+        /// The method <see cref="InferDataType"/> returns an enumeration that identifies both the native storage type, and method of conversion, that 
+        /// will be used when storing the property value. These defaults can be overridden via the <see cref="OverrideDataTypeAttribute"/>.
+        /// <para />
+        /// The method <see cref="ConvertPropertyTypeToStorageType{T}" /> is provided the current value of the property. It's job is to convert this value to
+        /// the native storage type based on <see cref="DataType"/> which is set via <see cref="InferDataType"/>.
+        /// <para />
+        /// The method <see cref="ConvertStorageTypeToPropertyType{T}" /> is the reverse of the above. Given an instance of the native storage type,
+        /// it's job is to convert it to an instance the property type.
+        /// <para />
+        /// The conversions between types in the default implementation follows this:
+        /// <list type="bullet">
+        ///  <item> <description>A property with a setting data type of <see cref="SettingDataType.Legacy"/> uses <see cref="BinaryFormatter"/> and stores it as a base64 encoded string. <see langword="null"/> values are stored as an empty string. </description></item>
+        ///  <item> <description>Array of <see cref="byte"/> is wrapped in a <see cref="MemoryStream"/>. <see langword="null"/> values are converted to an empty <see cref="MemoryStream"/>.</description></item>
+        ///  <item> <description><see cref="Color"/>, with setting data type <see cref="SettingDataType.Int32"/> uses To[From]Argb to store it as an Int32.</description></item>
+        ///  <item> <description><see cref="Guid"/>, with setting data type <see cref="SettingDataType.String"/> uses <see cref="Guid.ToString()"/> and <see cref="Guid.Parse"/> to convert to and from a string.</description></item>
+        ///  <item> <description><see cref="DateTime"/>, with setting data type <see cref="SettingDataType.Int64"/> uses To[From]Binary to store it as an Int64.</description></item>
+        ///  <item> <description><see cref="DateTimeOffset"/>, with setting data type <see cref="SettingDataType.String"/> uses the round-trip 'o' specifier to store as a string.</description></item>
+        ///  <item> <description><see cref="float"/> and <see cref="double"/>, with setting data type <see cref="SettingDataType.String"/> uses the round-trip 'G9' and 'G17' specifier to store as a string, and is parsed via the standard Convert method.</description></item>
+        ///  <item> <description><see cref="string"/>, if null, is stored as an empty string.</description></item>
+        ///  <item> <description>Enumerations are converted to/from their underlying type.</description></item>
+        ///  <item> <description><a href="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types">Integral numeric types</a>,
+        ///                      <see cref="float"/>, <see cref="double"/>, <see cref="decimal"/>, and <see cref="char"/>
+        ///                      use <see cref="Convert.ChangeType(object, Type, IFormatProvider)" />, using <see cref="CultureInfo.InvariantCulture"/>. Enumerations are
+        ///                      stored as their underlying integral numeric type.</description></item>
+        ///  <item> <description>Any type not described above, or a property with a setting data type of <see cref="SettingDataType.Serialized"/>
+        ///                      uses <see cref="BaseOptionModel{T}.SerializeValue"/> and <see cref="BaseOptionModel{T}.DeserializeValue"/> and stores it as binary,
+        ///                      refer to those overridable methods for details.</description></item>
+        /// </list>
+        /// </remarks>
+        protected virtual object ConvertPropertyTypeToStorageType<TOptMdl>(object? propertyValue, BaseOptionModel<TOptMdl> baseOptionModel) where TOptMdl : BaseOptionModel<TOptMdl>, new()
+        {
+            switch (DataType)
+            {
+                case SettingDataType.Serialized:
+                    if (NativeStorageType != NativeSettingsType.String)
+                        throw new InvalidOperationException($"The SettingDataType of Serialized is not capable of supporting native storage type {NativeStorageType}");
+                    string serializedString = baseOptionModel.SerializeValue(propertyValue, PropertyInfo.PropertyType, PropertyName);
+                    if (serializedString == null)
+                        throw new InvalidOperationException($"The SerializeValue method of {baseOptionModel.GetType().FullName} returned " +
+                            " a null value. This method cannot return null.");
+                    return serializedString;
+                case SettingDataType.Legacy:
+                    if (NativeStorageType != NativeSettingsType.String)
+                        throw new InvalidOperationException($"The SettingDataType of Legacy is not capable of supporting native storage type {NativeStorageType}");
+                    return LegacySerializeValue(propertyValue);
+            }
+
+            Type conversionType = NativeStorageType.GetDotNetType();
+            if (TypeConverter != null)
+            {
+                bool returnMemoryStream = false;
+                if (NativeStorageType == NativeSettingsType.Binary)
+                {
+                    // For binary, the type conversion should be to byte[], then we return a memory stream.
+                    returnMemoryStream = true;
+                    conversionType = typeof(byte[]);
+                }
+
+                if (!TypeConverter.CanConvertTo(conversionType))
+                    throw new InvalidOperationException($"TypeConverter {TypeConverter.GetType().FullName} can not convert {PropertyInfo.PropertyType.FullName} to {NativeStorageType} ({conversionType.Name})");
+
+                object? convertedObj = TypeConverter.ConvertTo(null, CultureInfo.InvariantCulture, propertyValue, conversionType);
+                if (convertedObj == null)
+                    throw new InvalidOperationException($"TypeConverter {TypeConverter.GetType().FullName} returned null converting from {PropertyInfo.PropertyType.FullName} to {NativeStorageType} ({conversionType.Name}), which is not supported.");
+                if (!conversionType.IsInstanceOfType(convertedObj))
+                    throw new InvalidOperationException($"TypeConverter {TypeConverter.GetType().FullName} returned type {convertedObj.GetType().FullName} when converting from {PropertyInfo.PropertyType.FullName} to {NativeStorageType} ({conversionType.Name}).");
+                if (returnMemoryStream)
+                    return new MemoryStream((byte[])convertedObj);
+                return convertedObj;
+            }
+
+            switch (NativeStorageType)
+            {
+                case NativeSettingsType.Int32:
+                    if (propertyValue is Color color)
+                        return color.ToArgb();
+                    break;
+                case NativeSettingsType.Int64:
+                    if (propertyValue is DateTime dt)
+                        return dt.ToBinary();
+                    break;
+                case NativeSettingsType.String:
+                    if (propertyValue is Guid guid)
+                        return guid.ToString();
+                    if (propertyValue is DateTimeOffset dtOffset)
+                        return dtOffset.ToString("o", CultureInfo.InvariantCulture);
+                    if (propertyValue is float floatVal)
+                        return floatVal.ToString("G9", CultureInfo.InvariantCulture);
+                    if (propertyValue is double doubleVal)
+                        return doubleVal.ToString("G17", CultureInfo.InvariantCulture);
+                    if (propertyValue == null)
+                        return string.Empty;
+                    break;
+                case NativeSettingsType.Binary:
+                    if (propertyValue is byte[] bytes)
+                        return new MemoryStream(bytes);
+                    if (propertyValue is MemoryStream memStream)
+                        return memStream;
+                    if (propertyValue == null)
+                        return new MemoryStream();
+                    throw new InvalidOperationException($"Can not convert NativeStorageType of Binary to {propertyValue.GetType().FullName} - property type must be byte[] or MemoryStream.");
+            }
+
+            if (propertyValue == null)
+                throw new InvalidOperationException($"A null property value with SettingDataType of {DataType} is not supported.");
+
+            if (conversionType.IsInstanceOfType(propertyValue))
+                return propertyValue;
+
+            return Convert.ChangeType(propertyValue, conversionType, CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>   Convert the <paramref name="settingsStoreValue"/> retrieved from the settings store to the type of the
+        /// property we are wrapping. See remarks at <see cref="ConvertPropertyTypeToStorageType{T}"/></summary>
+        /// <typeparam name="TOptMdl">  Type of <see cref="BaseOptionModel{TOptMdl}"/>. </typeparam>
+        /// <param name="settingsStoreValue">                The value retrieved from the settings store, as an object. This will not be null. </param>
+        /// <param name="baseOptionModel">      Instance of <see cref="BaseOptionModel{TOptMdl}"/>. For types requiring deserialization, methods in this object are used. </param>
+        /// <returns>   <paramref name="settingsStoreValue"/>, converted to the property type. </returns>
+        protected virtual object? ConvertStorageTypeToPropertyType<TOptMdl>(object settingsStoreValue, BaseOptionModel<TOptMdl> baseOptionModel) where TOptMdl : BaseOptionModel<TOptMdl>, new()
+        {
+            Type typeOfWrappedProperty = PropertyInfo.PropertyType;
+            if (typeOfWrappedProperty.IsEnum)
+                typeOfWrappedProperty = typeOfWrappedProperty.GetEnumUnderlyingType();
+
+            switch (DataType)
+            {
+                case SettingDataType.Serialized:
+                    if (NativeStorageType != NativeSettingsType.String)
+                        throw new InvalidOperationException($"The SettingDataType of Serialized must be SettingsType.String. Was: {NativeStorageType}");
+                    return baseOptionModel.DeserializeValue((string)settingsStoreValue, typeOfWrappedProperty, PropertyName);
+                case SettingDataType.Legacy:
+                    if (NativeStorageType != NativeSettingsType.String)
+                        throw new InvalidOperationException($"The SettingDataType of Legacy must be SettingsType.String. Was: {NativeStorageType}");
+                    return LegacyDeserializeValue((string)settingsStoreValue, typeOfWrappedProperty);
+            }
+
+            if (TypeConverter != null)
+            {
+                Type valueType = settingsStoreValue.GetType();
+                if (NativeStorageType == NativeSettingsType.Binary)
+                {
+                    // Type converter uses byte[] so extract byte array and set the conversion type.
+                    valueType = typeof(byte[]);
+                    settingsStoreValue = ((MemoryStream)settingsStoreValue).ToArray();
+                }
+                if (!TypeConverter.CanConvertFrom(valueType))
+                    throw new InvalidOperationException($"TypeConverter {TypeConverter.GetType().FullName} can not convert from {valueType.Name} to {typeOfWrappedProperty.FullName}.");
+
+                object? returnObject = TypeConverter.ConvertFrom(null!, CultureInfo.InvariantCulture, settingsStoreValue);
+                if (returnObject == null)
+                {
+                    if (typeOfWrappedProperty.IsValueType)
+                        throw new InvalidOperationException($"TypeConverter {TypeConverter.GetType().FullName} attempt to convert from {valueType.Name} to {typeOfWrappedProperty.FullName} returned null for a value type.");
+                    return returnObject;
+                }
+                if (!typeOfWrappedProperty.IsInstanceOfType(returnObject))
+                    throw new InvalidOperationException($"TypeConverter {TypeConverter.GetType().FullName} attempt to convert from {valueType.Name} to {typeOfWrappedProperty.FullName} returned incompatible type {returnObject.GetType().FullName}.");
+                return returnObject;
+            }
+
+            switch (NativeStorageType)
+            {
+                case NativeSettingsType.Int32:
+                    if (typeOfWrappedProperty == typeof(Color))
+                        return Color.FromArgb((int)settingsStoreValue);
+                    break;
+                case NativeSettingsType.Int64:
+                    if (typeOfWrappedProperty == typeof(DateTime))
+                        return DateTime.FromBinary((long)settingsStoreValue);
+                    break;
+                case NativeSettingsType.String:
+                    if (typeOfWrappedProperty == typeof(Guid))
+                        return Guid.Parse((string)settingsStoreValue);
+                    if (typeOfWrappedProperty == typeof(DateTimeOffset))
+                        return DateTimeOffset.Parse((string)settingsStoreValue, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+                    break;
+                case NativeSettingsType.Binary:
+                    if (typeOfWrappedProperty == typeof(MemoryStream))
+                        return (MemoryStream)settingsStoreValue;
+                    if (typeOfWrappedProperty == typeof(byte[]))
+                        return ((MemoryStream)settingsStoreValue).ToArray();
+                    throw new InvalidCastException($"Can not convert SettingsType.Binary to {typeOfWrappedProperty.FullName} - property type must be byte[] or MemoryStream.");
+            }
+
+            if (typeOfWrappedProperty.IsInstanceOfType(settingsStoreValue))
+                return settingsStoreValue;
+
+            return Convert.ChangeType(settingsStoreValue, typeOfWrappedProperty, CultureInfo.InvariantCulture);
+        }
+
+        #endregion Type inference and conversion
+    }
+}

--- a/src/Community.VisualStudio.Toolkit.Shared/Options/OverrideCollectionNameAttribute.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Options/OverrideCollectionNameAttribute.cs
@@ -5,23 +5,22 @@ namespace Community.VisualStudio.Toolkit
 {
     /// <summary>   Apply this attribute on an individual get/set property in your <see cref="BaseOptionModel{T}"/> 
     ///             derived class to use a specific <c>CollectionName</c> to store a given property in the 
-    ///             <see cref="WritableSettingsStore"/> rather than using the <see cref="BaseOptionModel{T}.CollectionName"/>.
+    ///             <see cref="SettingsStore"/> rather than using the <see cref="BaseOptionModel{T}.CollectionName"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
     public class OverrideCollectionNameAttribute : Attribute
     {
-        /// <summary>   Specifies the <c>CollectionName</c> in the <see cref="WritableSettingsStore"/> where
-        ///             this setting is stored rather than using the default, which is the <c>FullName</c>
-        ///             of the typeparam <c>T</c>. </summary>
+        /// <summary>   Specifies the <c>CollectionName</c> in the <see cref="SettingsStore"/> where
+        ///             this setting is stored rather than using the default. </summary>
         /// <param name="collectionName">   This value is used as the <c>collectionPath</c> parameter when reading 
-        ///                                 and writing using the <see cref="WritableSettingsStore"/>.  </param>
+        ///                                 and writing using the <see cref="SettingsStore"/>.  </param>
         public OverrideCollectionNameAttribute(string collectionName)
         {
             CollectionName = collectionName;
         }
 
         /// <summary>   This value is used as the <c>collectionPath</c> parameter when reading
-        ///             and writing using the <see cref="WritableSettingsStore"/>.  </summary>
+        ///             and writing using the <see cref="SettingsStore"/>.  </summary>
         public string CollectionName { get; }
     }
 }

--- a/src/Community.VisualStudio.Toolkit.Shared/Options/OverrideDataTypeAttribute.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Options/OverrideDataTypeAttribute.cs
@@ -1,25 +1,46 @@
 ﻿using System;
+using System.Globalization;
 using Microsoft.VisualStudio.Settings;
 
 namespace Community.VisualStudio.Toolkit
 {
     /// <summary>   Apply this attribute on a get/set property in the <see cref="BaseOptionModel{T}"/> class to 
-    ///             alter the default mechanism used to store/retrieve the value of this property from the
-    ///             <see cref="WritableSettingsStore"/>. If not specified, the <see cref="SettingDataType"/><c>.Serialized</c>
-    ///             mechanism is used.  </summary>
+    ///             specify the type and mechanism used to store/retrieve the value of this property in the
+    ///             <see cref="SettingsStore"/>. If not specified, the default mechanism is used is based on the 
+    ///             property type. </summary>
     [AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
     public class OverrideDataTypeAttribute : Attribute
     {
-        /// <summary>   Alters the default mechanism used to store/retrieve the value of this property from the setting store. </summary>
-        /// <param name="settingDataType">  Specifies the type and/or method used to store and retrieve the value of the attributed 
-        ///                                 property in the <see cref="WritableSettingsStore"/>. </param>
-        public OverrideDataTypeAttribute(SettingDataType settingDataType)
+        /// <summary>   Alters the default type and mechanism used to store/retrieve the value of this
+        ///             property in the <see cref="SettingsStore"/>. </summary>
+        /// <param name="settingDataType">  Specifies the type and/or method used to store and retrieve
+        ///                                 the value of the attributed property in the
+        ///                                 <see cref="SettingsStore"/>. </param>
+        /// <param name="useTypeConverter"> (Optional, default <see langword="false"/>) If <see langword="true"/>, 
+        ///                                 and the type has a <see cref="System.ComponentModel.TypeConverterAttribute"/>
+        ///                                 that allows for conversion to <paramref name="settingDataType"/>, this
+        ///                                 will be used to convert and store the property value. If the 
+        ///                                 <paramref name="settingDataType"/> is <c>Legacy</c> or <c>Serialized</c>
+        ///                                 this has no effect. For other <see cref="SettingDataType"/> values, 
+        ///                                 <see langword="false"/> will use the default conversion mechanism of
+        ///                                 <see cref="Convert.ChangeType(object, Type, IFormatProvider)" />, using
+        ///                                 <see cref="CultureInfo.InvariantCulture"/>. </param>
+        public OverrideDataTypeAttribute(SettingDataType settingDataType, bool useTypeConverter = false)
         {
             SettingDataType = settingDataType;
+            UseTypeConverter = useTypeConverter;
         }
 
-        /// <summary>   Specifies the type and/or method used to store and retrieve the value of the attributed
-        ///             property in the <see cref="WritableSettingsStore"/>.</summary>
+        /// <summary>   Specifies the type and method used to store and retrieve the value of the attributed
+        ///             property in the <see cref="SettingsStore"/>.</summary>
         public SettingDataType SettingDataType { get; }
+
+        /// <summary>   If <see langword="true"/>, and the type has a <see cref="System.ComponentModel.TypeConverterAttribute"/>
+        ///  that allows for conversion to <see cref="SettingDataType"/>, this will be used to convert and store the property value. 
+        ///  If the <see cref="SettingDataType"/> is <c>Legacy</c> or <c>Serialized</c> this has no effect. For other 
+        ///  <see cref="SettingDataType"/>, <see langword="false"/> will use the default conversion mechanism of 
+        ///  <see cref="Convert.ChangeType(object, Type, IFormatProvider)" />, using 
+        ///  <see cref="CultureInfo.InvariantCulture"/>. </summary>
+        public bool UseTypeConverter { get; }
     }
 }

--- a/src/Community.VisualStudio.Toolkit.Shared/Options/OverridePropertyNameAttribute.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Options/OverridePropertyNameAttribute.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Microsoft.VisualStudio.Settings;
+
+namespace Community.VisualStudio.Toolkit
+{
+    /// <summary>   Apply this attribute on an individual public get/set property in your <see cref="BaseOptionModel{T}"/> 
+    ///             derived class to use a specific <c>propertyName</c> to store a given property in the
+    ///             <see cref="SettingsStore"/> rather than using the name of the property.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
+    public class OverridePropertyNameAttribute : Attribute
+    {
+        /// <summary>   Specifies the <c>propertyName</c> in the <see cref="SettingsStore"/> where
+        ///             this setting is stored rather than using the default, which is the name of 
+        ///             the property. </summary>
+        /// <param name="propertyName">   This value is used as the <c>propertyName</c> parameter when reading
+        ///                                 and writing to the <see cref="SettingsStore"/>.  </param>
+        public OverridePropertyNameAttribute(string propertyName)
+        {
+            PropertyName = propertyName;
+        }
+
+        /// <summary>   This value is used as the <c>propertyName</c> parameter when reading
+        ///             and writing to the <see cref="SettingsStore"/>.  </summary>
+        public string PropertyName { get; }
+    }
+}

--- a/src/Community.VisualStudio.Toolkit.Shared/Options/SettingDataType.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Options/SettingDataType.cs
@@ -1,43 +1,49 @@
 ﻿using System;
+using System.IO;
+using System.Globalization;
 using Microsoft.VisualStudio.Settings;
 
 namespace Community.VisualStudio.Toolkit
 {
-    /// <summary>   Enumeration that specifies the underlying type that is to be stored/retrieved from the
-    ///             <see cref="WritableSettingsStore"/>.  </summary>
+    /// <summary>   Enumeration that specifies both the underlying type that is to be stored/retrieved from the
+    ///             <see cref="SettingsStore"/> and method of type conversion.  </summary>
     public enum SettingDataType
     {
-        /// <summary>   Uses the <see cref="WritableSettingsStore"/>.<see cref="WritableSettingsStore.SetString"/>
-        /// to update the value of the attributed property (of any <see cref="Type.IsSerializable"/> type), using 
-        /// an underlying string type in the settings store. The raw value of the property is first serialized 
-        /// to a string for storage, using the means specified in <see cref="BaseOptionModel{T}"/>. This differs
-        /// from <see cref="String"/> because with this option the underlying type IS ALWAYS serialized prior 
-        /// to storage. </summary>
-        Serialized,
-        /// <summary>   Uses the <see cref="WritableSettingsStore"/>.<see cref="WritableSettingsStore.SetString"/>
-        /// to update the value of the attributed <see cref="string"/> property, using an underlying string type
-        /// in the settings store. This differs from <see cref="Serialized"/> because with this option the raw 
-        /// string is stored and IS NEVER serialized. </summary>
+        /// <summary>   Value of the property is persisted in the <see cref="SettingsStore"/> as a <see cref="string"/>.
+        /// <see langword="null"/> strings are converted to an empty string, therefore will not round-trip.
+        /// Type conversions, if needed, are performed via <see cref="Convert.ChangeType(object, Type, IFormatProvider)" />, 
+        /// using <see cref="CultureInfo.InvariantCulture"/>. Types such as <see cref="float"/>, <see cref="double"/>, 
+        /// <see cref="decimal"/>, and <see cref="char"/> are stored this way. </summary>
         String,
-        /// <summary>   Uses the <see cref="WritableSettingsStore"/>.<see cref="WritableSettingsStore.SetBoolean"/>
-        /// to update the value of the attributed <see cref="bool"/> property, using an underlying Int32 type 
-        /// in the settings store. </summary>
-        Bool,
-        /// <summary>   Uses the <see cref="WritableSettingsStore"/>.<see cref="WritableSettingsStore.SetInt32"/>
-        /// to update the value of the attributed <see cref="Int32"/> property, using an underlying Int32 type
-        /// in the settings store. </summary>
+        /// <summary>   Value of the property is persisted in the <see cref="SettingsStore"/> as an <see cref="int"/>.
+        /// Type conversions, if needed, are performed via <see cref="Convert.ChangeType(object, Type, IFormatProvider)" />,
+        /// using <see cref="CultureInfo.InvariantCulture"/>. <see cref="System.Drawing.Color"/> is converted using To[From]Argb. </summary>
         Int32,
-        /// <summary>   Uses the <see cref="WritableSettingsStore"/>.<see cref="WritableSettingsStore.SetUInt32"/>
-        /// to update the value of the attributed <see cref="UInt32"/> property, using an underlying UInt32 type
-        /// in the settings store. </summary>
+        /// <summary>   Value of the property is persisted in the <see cref="SettingsStore"/> as an <see cref="uint"/>.
+        /// Type conversions, if needed, are performed via <see cref="Convert.ChangeType(object, Type, IFormatProvider)" />,
+        /// using <see cref="CultureInfo.InvariantCulture"/>. </summary>
         UInt32,
-        /// <summary>   Uses the <see cref="WritableSettingsStore"/>.<see cref="WritableSettingsStore.SetInt64"/>
-        /// to update the value of the attributed <see cref="Int64"/> property, using an underlying Int64 type
-        /// in the settings store. </summary>
+        /// <summary>   Value of the property is persisted in the <see cref="SettingsStore"/> as an <see cref="long"/>.
+        /// Type conversions, if needed, are performed via <see cref="Convert.ChangeType(object, Type, IFormatProvider)" />,
+        /// using <see cref="CultureInfo.InvariantCulture"/>. <see cref="DateTime"/> is converted via To[From]Binary, and 
+        /// <see cref="DateTimeOffset"/> is converted via To[From]UnixTimeMilliseconds. </summary>
         Int64,
-        /// <summary>   Uses the <see cref="WritableSettingsStore"/>.<see cref="WritableSettingsStore.SetUInt64"/>
-        /// to update the value of the attributed <see cref="UInt64"/> property, using an underlying UInt64 type
-        /// in the settings store. </summary>
+        /// <summary>   Value of the property is persisted in the <see cref="SettingsStore"/> as an <see cref="ulong"/>.
+        /// Type conversions, if needed, are performed via <see cref="Convert.ChangeType(object, Type, IFormatProvider)" />,
+        /// using <see cref="CultureInfo.InvariantCulture"/>. </summary>
         UInt64,
+        /// <summary>   Value of the property is persisted in the <see cref="SettingsStore"/> as a <see cref="MemoryStream"/>.
+        /// Array of <see cref="byte"/> is wrapped in a <see cref="MemoryStream"/>. <see langword="null"/> values are converted 
+        /// to an empty <see cref="MemoryStream"/>, therefore will not round-trip. </summary>
+        Binary,
+        /// <summary>   Value of the property is persisted in the <see cref="SettingsStore"/> as a <see cref="string"/>.
+        /// Conversion uses <see cref="System.Runtime.Serialization.Formatters.Binary.BinaryFormatter"/>, with the bytes converted
+        /// to/from a Base64 encoded string, the string value is what is stored. <see langword="null"/> values are stored 
+        /// as an empty string. </summary>
+        Legacy,
+        /// <summary>   Value of the property is persisted in the <see cref="SettingsStore"/> as a <see cref="string"/>.
+        /// The methods <see cref="BaseOptionModel{T}.SerializeValue"/> and <see cref="BaseOptionModel{T}.DeserializeValue"/> are
+        /// used to convert to and from storage. </summary>
+        Serialized,
     }
 }

--- a/src/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
+++ b/src/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
@@ -17,6 +17,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\IVsTextViewExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MEF\WpfTextViewCreationListener.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Build\BuildEvents.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Options\IOptionModelPropertyWrapper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Options\NativeSettingsType.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Options\OptionModelPropertyWrapper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Options\OverridePropertyNameAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Selection\Selection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Shell\ShellEvents.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Debugger\DebuggerEvents.cs" />

--- a/src/Community.VisualStudio.Toolkit.UnitTests/App.config
+++ b/src/Community.VisualStudio.Toolkit.UnitTests/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <system.diagnostics>
+    <assert assertuienabled="false"/>
+  </system.diagnostics>
+</configuration>

--- a/src/Community.VisualStudio.Toolkit.UnitTests/Community.VisualStudio.Toolkit.UnitTests.csproj
+++ b/src/Community.VisualStudio.Toolkit.UnitTests/Community.VisualStudio.Toolkit.UnitTests.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <DefineConstants>VS17;XUNIT</DefineConstants>
+    <LangVersion>9</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System.Design" />
+    <Reference Include="System.Windows" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  
+  <Import Project="$(MSBuildThisFileDirectory)\..\Community.VisualStudio.Toolkit.Shared\VSSDK.Helpers.Shared.projitems" Label="Shared" />
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-1-31410-273" IncludeAssets="All" PrivateAssets="None" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/src/Community.VisualStudio.Toolkit.UnitTests/OptionModelPropertyWrapperTests.cs
+++ b/src/Community.VisualStudio.Toolkit.UnitTests/OptionModelPropertyWrapperTests.cs
@@ -1,0 +1,1153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using FluentAssertions;
+using Microsoft.VisualStudio.Settings;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Community.VisualStudio.Toolkit.UnitTests
+{
+    public enum TestValueType
+    {
+        Default,
+        Alternate,
+    }
+
+    public class OptionModelPropertyWrapperTests
+    {
+        public const string TestCollectionName = "MyCollectionName";
+        public const string OverrideCollectionName = "OverrideCollectionName";
+        public const string OverridePropertyName = "OverridePropertyName";
+
+        private readonly ITestOutputHelper _output;
+
+        public OptionModelPropertyWrapperTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void PropertyTypeString()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.String));
+
+            string defaultValueProperty = "default";
+            string expectedDefaultValueInStore = defaultValueProperty;
+
+            string expectedAlternateValueProperty = "loaded";
+            string expectedAlternateValueInStore = expectedAlternateValueProperty;
+
+            SettingStoreTest_String(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.String, s => objUt.String = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeString_Null()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.String));
+
+            // A null string is stored as an empty string, it does not round-trip.
+            string? defaultValueProperty = null;
+            string expectedDefaultValueInStore = string.Empty;
+
+            string expectedAlternateValueProperty = "loaded";
+            string expectedAlternateValueInStore = expectedAlternateValueProperty;
+
+            void OverrideAssertEquality(TestValueType valueBeingTested, string? expected, string? actual, string because)
+            {
+                if (valueBeingTested == TestValueType.Default)
+                    actual.Should().BeEquivalentTo(string.Empty, because + " A null string should roundtrip as an empty string");
+                else
+                    actual.Should().BeEquivalentTo(expected, because);
+            }
+
+            SettingStoreTest_String(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.String, s => objUt.String = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore,
+                OverrideAssertEquality);
+        }
+
+        [Fact]
+        public void PropertyTypeFloat()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.Float));
+
+            float defaultValueProperty = float.MinValue;
+            string expectedDefaultValueInStore = defaultValueProperty.ToString("G9", CultureInfo.InvariantCulture);
+
+            float expectedAlternateValueProperty = float.MaxValue;
+            string expectedAlternateValueInStore = expectedAlternateValueProperty.ToString("G9", CultureInfo.InvariantCulture);
+
+            SettingStoreTest_String(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.Float, s => objUt.Float = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeDouble()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.Double));
+
+            double defaultValueProperty = double.MinValue;
+            string expectedDefaultValueInStore = defaultValueProperty.ToString("G17", CultureInfo.InvariantCulture);
+
+            double expectedAlternateValueProperty = double.MaxValue;
+            string expectedAlternateValueInStore = expectedAlternateValueProperty.ToString("G17", CultureInfo.InvariantCulture);
+
+            SettingStoreTest_String(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.Double, s => objUt.Double = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeDecimal()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.Decimal));
+
+            decimal defaultValueProperty = decimal.MinValue;
+            string expectedDefaultValueInStore = defaultValueProperty.ToString(CultureInfo.InvariantCulture);
+
+            decimal expectedAlternateValueProperty = decimal.MaxValue;
+            string expectedAlternateValueInStore = expectedAlternateValueProperty.ToString(CultureInfo.InvariantCulture);
+
+            SettingStoreTest_String(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.Decimal, s => objUt.Decimal = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeChar()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.Char));
+
+            char defaultValueProperty = 'a';
+            string expectedDefaultValueInStore = defaultValueProperty.ToString(CultureInfo.InvariantCulture);
+
+            char expectedAlternateValueProperty = 'Z';
+            string expectedAlternateValueInStore = expectedAlternateValueProperty.ToString(CultureInfo.InvariantCulture);
+
+            SettingStoreTest_String(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.Char, s => objUt.Char = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeGuid()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.Guid));
+
+            Guid defaultValueProperty = Guid.Parse("{3932BCBE-E660-4E08-BBE8-68812D9574C8}");
+            string expectedDefaultValueInStore = defaultValueProperty.ToString();
+
+            Guid expectedAlternateValueProperty = Guid.Parse("{605689E1-96F9-46FA-BC9C-57CAE005848B}");
+            string expectedAlternateValueInStore = expectedAlternateValueProperty.ToString();
+
+            SettingStoreTest_String(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.Guid, s => objUt.Guid = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeBoolean()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.Bool));
+
+            bool defaultValueProperty = false;
+            int expectedDefaultValueInStore = 0;
+
+            bool expectedAlternateValueProperty = true;
+            int expectedAlternateValueInStore = 1;
+
+            SettingStoreTest_Int32(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.Bool, s => objUt.Bool = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeSByte()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.SByte));
+
+            sbyte defaultValueProperty = sbyte.MinValue;
+            int expectedDefaultValueInStore = (int)defaultValueProperty;
+
+            sbyte expectedAlternateValueProperty = sbyte.MaxValue;
+            int expectedAlternateValueInStore = (int)expectedAlternateValueProperty;
+
+            SettingStoreTest_Int32(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.SByte, s => objUt.SByte = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeByte()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.Byte));
+
+            byte defaultValueProperty = byte.MinValue;
+            int expectedDefaultValueInStore = (int)defaultValueProperty;
+
+            byte expectedAlternateValueProperty = byte.MaxValue;
+            int expectedAlternateValueInStore = (int)expectedAlternateValueProperty;
+
+            SettingStoreTest_Int32(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.Byte, s => objUt.Byte = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeShort()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.Short));
+
+            short defaultValueProperty = short.MinValue;
+            int expectedDefaultValueInStore = (int)defaultValueProperty;
+
+            short expectedAlternateValueProperty = short.MaxValue;
+            int expectedAlternateValueInStore = (int)expectedAlternateValueProperty;
+
+            SettingStoreTest_Int32(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.Short, s => objUt.Short = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeUShort()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.UShort));
+
+            ushort defaultValueProperty = ushort.MinValue;
+            int expectedDefaultValueInStore = (int)defaultValueProperty;
+
+            ushort expectedAlternateValueProperty = ushort.MaxValue;
+            int expectedAlternateValueInStore = (int)expectedAlternateValueProperty;
+
+            SettingStoreTest_Int32(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.UShort, s => objUt.UShort = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeInt()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.Int));
+
+            int defaultValueProperty = int.MinValue;
+            int expectedDefaultValueInStore = (int)defaultValueProperty;
+
+            int expectedAlternateValueProperty = int.MaxValue;
+            int expectedAlternateValueInStore = (int)expectedAlternateValueProperty;
+
+            SettingStoreTest_Int32(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.Int, s => objUt.Int = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeInt_OverridePropertyName()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.IntPropertyName));
+
+            int defaultValueProperty = int.MinValue;
+            int expectedDefaultValueInStore = (int)defaultValueProperty;
+
+            int expectedAlternateValueProperty = int.MaxValue;
+            int expectedAlternateValueInStore = (int)expectedAlternateValueProperty;
+
+            SettingStoreTest_Int32(objUt, TestCollectionName, OverridePropertyName, propertyUt, () => objUt.IntPropertyName, s => objUt.IntPropertyName = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeInt_OverrideCollectionName()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.IntCollectionName));
+
+            int defaultValueProperty = int.MinValue;
+            int expectedDefaultValueInStore = (int)defaultValueProperty;
+
+            int expectedAlternateValueProperty = int.MaxValue;
+            int expectedAlternateValueInStore = (int)expectedAlternateValueProperty;
+
+            SettingStoreTest_Int32(objUt, OverrideCollectionName, propertyUt.Name, propertyUt, () => objUt.IntCollectionName, s => objUt.IntCollectionName = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeColor()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.Color));
+
+            Color defaultValueProperty = Color.FromArgb(50, 40, 30, 10);
+            int expectedDefaultValueInStore = defaultValueProperty.ToArgb();
+
+            Color expectedAlternateValueProperty = Color.FromArgb(80, 70, 60, 50);
+            int expectedAlternateValueInStore = expectedAlternateValueProperty.ToArgb();
+
+            SettingStoreTest_Int32(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.Color, s => objUt.Color = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeUInt()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.UInt));
+
+            uint defaultValueProperty = uint.MinValue;
+            uint expectedDefaultValueInStore = defaultValueProperty;
+
+            uint expectedAlternateValueProperty = uint.MaxValue;
+            uint expectedAlternateValueInStore = expectedAlternateValueProperty;
+
+            SettingStoreTest_UInt32(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.UInt, s => objUt.UInt = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeLong()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.Long));
+
+            long defaultValueProperty = long.MinValue;
+            long expectedDefaultValueInStore = defaultValueProperty;
+
+            long expectedAlternateValueProperty = long.MaxValue;
+            long expectedAlternateValueInStore = expectedAlternateValueProperty;
+
+            SettingStoreTest_Int64(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.Long, s => objUt.Long = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeDateTime()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.DateTime));
+
+            DateTime defaultValueProperty = DateTime.UtcNow;
+            long expectedDefaultValueInStore = defaultValueProperty.ToBinary();
+
+            DateTime expectedAlternateValueProperty = defaultValueProperty + TimeSpan.FromMinutes(30);
+            long expectedAlternateValueInStore = expectedAlternateValueProperty.ToBinary();
+
+            SettingStoreTest_Int64(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.DateTime, s => objUt.DateTime = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeDateTimeOffset()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.DateTimeOffset));
+
+            DateTimeOffset defaultValueProperty = DateTimeOffset.MinValue;
+            string expectedDefaultValueInStore = defaultValueProperty.ToString("o");
+
+            DateTimeOffset expectedAlternateValueProperty = DateTimeOffset.MaxValue;
+            string expectedAlternateValueInStore = expectedAlternateValueProperty.ToString("o");
+
+            SettingStoreTest_String(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.DateTimeOffset, s => objUt.DateTimeOffset = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeULong()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.ULong));
+
+            ulong defaultValueProperty = ulong.MinValue;
+            ulong expectedDefaultValueInStore = defaultValueProperty;
+
+            ulong expectedAlternateValueProperty = ulong.MaxValue;
+            ulong expectedAlternateValueInStore = expectedAlternateValueProperty;
+
+            SettingStoreTest_UInt64(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.ULong, s => objUt.ULong = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeByteArray()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.ByteArray));
+
+            byte[] defaultValueProperty = new byte[] { 0, 1, 2, 3, 4 };
+            byte[] expectedDefaultValueInStore = defaultValueProperty;
+
+            byte[] expectedAlternateValueProperty = new byte[] { 5, 6, 7, 8 };
+            byte[] expectedAlternateValueInStore = expectedAlternateValueProperty;
+
+            SettingStoreTest_MemoryStream(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.ByteArray, s => objUt.ByteArray = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeEnumeration()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.Enumeration));
+
+            NativeSettingsType defaultValueProperty = NativeSettingsType.UInt64;
+            int expectedDefaultValueInStore = (int)defaultValueProperty;
+
+            NativeSettingsType expectedAlternateValueProperty = NativeSettingsType.Int32;
+            int expectedAlternateValueInStore = (int)expectedAlternateValueProperty;
+
+            SettingStoreTest_Int32(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.Enumeration, s => objUt.Enumeration = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void PropertyTypeBooleanStoredAsUInt64_OverrideDataType()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.BoolStoredAsUInt64));
+
+            bool defaultValueProperty = false;
+            uint expectedDefaultValueInStore = 0;
+
+            bool expectedAlternateValueProperty = true;
+            uint expectedAlternateValueInStore = 1;
+
+            SettingStoreTest_UInt64(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.BoolStoredAsUInt64, s => objUt.BoolStoredAsUInt64 = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void CustomType()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.CustomType));
+
+            CustomType defaultValueProperty = new() { StringValue = "default" };
+            string? expectedDefaultValueInStore = objUt.SerializeValue(defaultValueProperty, typeof(CustomType), propertyUt.Name);
+
+            CustomType expectedAlternateValueProperty = new() { StringValue = "loaded" };
+            string? expectedAlternateValueInStore = objUt.SerializeValue(expectedAlternateValueProperty, typeof(CustomType), propertyUt.Name);
+
+            SettingStoreTest_String(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.CustomType, s => objUt.CustomType = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void CustomType_TypeConverterBinary()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.CustomType_TypeConverterBinary));
+
+            CustomTypeConverter converter = new();
+
+            CustomType defaultValueProperty = new() { StringValue = "default" };
+            byte[] expectedDefaultValueInStore = (byte[])converter.ConvertTo(defaultValueProperty, typeof(byte[]));
+
+            CustomType expectedAlternateValueProperty = new() { StringValue = "loaded" };
+            byte[] expectedAlternateValueInStore = (byte[])converter.ConvertTo(expectedAlternateValueProperty, typeof(byte[]));
+
+            SettingStoreTest_MemoryStream(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.CustomType_TypeConverterBinary, s => objUt.CustomType_TypeConverterBinary = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void CustomType_TypeConverterBinary_Null()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.CustomType_TypeConverterBinary));
+
+            CustomTypeConverter converter = new();
+
+            CustomType? defaultValueProperty = null;
+            byte[] expectedDefaultValueInStore = (byte[])converter.ConvertTo(defaultValueProperty!, typeof(byte[]));
+
+            CustomType expectedAlternateValueProperty = new() { StringValue = "loaded" };
+            byte[] expectedAlternateValueInStore = (byte[])converter.ConvertTo(expectedAlternateValueProperty, typeof(byte[]));
+
+            SettingStoreTest_MemoryStream(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.CustomType_TypeConverterBinary, s => objUt.CustomType_TypeConverterBinary = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void CustomType_TypeConverterString()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.CustomType_TypeConverterString));
+
+            CustomTypeConverter converter = new();
+
+            CustomType defaultValueProperty = new() { StringValue = "default" };
+            string expectedDefaultValueInStore = (string)converter.ConvertTo(defaultValueProperty, typeof(string));
+
+            CustomType expectedAlternateValueProperty = new() { StringValue = "loaded" };
+            string expectedAlternateValueInStore = (string)converter.ConvertTo(expectedAlternateValueProperty, typeof(string));
+
+            SettingStoreTest_String(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.CustomType_TypeConverterString, s => objUt.CustomType_TypeConverterString = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void CustomType_TypeConverterString_Null()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.CustomType_TypeConverterString));
+
+            CustomTypeConverter converter = new();
+
+            CustomType? defaultValueProperty = null;
+            string expectedDefaultValueInStore = (string)converter.ConvertTo(defaultValueProperty, typeof(string));
+
+            CustomType expectedAlternateValueProperty = new() { StringValue = "loaded" };
+            string expectedAlternateValueInStore = (string)converter.ConvertTo(expectedAlternateValueProperty, typeof(string));
+
+            SettingStoreTest_String(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.CustomType_TypeConverterString, s => objUt.CustomType_TypeConverterString = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void ListOfStringLegacy()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.ListOfStringLegacy));
+
+            List<string> defaultValueProperty = new(new[] { "initial", "second" });
+            string expectedDefaultValueInStore = OptionModelPropertyWrapper.LegacySerializeValue(defaultValueProperty);
+
+            List<string> expectedAlternateValueProperty = new(new[] { "loaded", "second" });
+            string expectedAlternateValueInStore = OptionModelPropertyWrapper.LegacySerializeValue(expectedAlternateValueProperty);
+
+            SettingStoreTest_String(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.ListOfStringLegacy, s => objUt.ListOfStringLegacy = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void ListOfStringLegacy_Null()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.ListOfStringLegacy));
+
+            List<string>? defaultValueProperty = null;
+            string expectedDefaultValueInStore = string.Empty;
+
+            List<string> expectedAlternateValueProperty = new(new[] { "loaded", "second" });
+            string expectedAlternateValueInStore = OptionModelPropertyWrapper.LegacySerializeValue(expectedAlternateValueProperty);
+
+            SettingStoreTest_String(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.ListOfStringLegacy, s => objUt.ListOfStringLegacy = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        [Fact]
+        public void ListOfString()
+        {
+            TestBom objUt = new();
+            PropertyInfo propertyUt = objUt.GetType().GetProperty(nameof(TestBom.ListOfString));
+
+            List<string> defaultValueProperty = new(new[] { "initial", "second" });
+            string expectedDefaultValueInStore = objUt.SerializeValue(defaultValueProperty, propertyUt.PropertyType, propertyUt.Name);
+
+            List<string> expectedAlternateValueProperty = new(new[] { "loaded", "second" });
+            string expectedAlternateValueInStore = objUt.SerializeValue(expectedAlternateValueProperty, propertyUt.PropertyType, propertyUt.Name);
+
+            SettingStoreTest_String(objUt, TestCollectionName, propertyUt.Name, propertyUt, () => objUt.ListOfString, s => objUt.ListOfString = s,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        #region Test Helper Methods and Main Test Method
+
+        /// <summary>   Helper Test Method, used for testing properties where the underlying <see cref="SettingsStore"/> type is 
+        ///             a <see cref="string"/>.</summary>
+        /// <typeparam name="TPropertyType">    The property type of the wrapped property, <paramref name="propertyUt"/>. </typeparam>
+        /// <typeparam name="TOptMdl">    The type of the base option model class that is the target object for the test. </typeparam>
+        /// <param name="objUt">                            An instance of the <see cref="BaseOptionModel{T}"/>, containing <paramref name="propertyUt"/>. </param>
+        /// <param name="collectionPath">                   The <c>collectionPath</c> that will be used when reading/writing to the settings store.. </param>
+        /// <param name="propertyName">                     The <c>propertyName</c> that will be used when reading/writing to the settings store. </param>
+        /// <param name="propertyUt">                       The property being wrapped for the test. </param>
+        /// <param name="getProperty">                      Delegate to get the property value (represented by <paramref name="propertyUt"/>) from <paramref name="objUt"/>. </param>
+        /// <param name="setProperty">                      Delegate to set the property (represented by <paramref name="propertyUt"/>) on <paramref name="objUt"/>. </param>
+        /// <param name="defaultValueProperty">             Prior to test, the property will be set to this value using <paramref name="setProperty"/>.
+        ///                                                 This is the expected value of the property after <c>Load</c> returns when the setting store get
+        ///                                                 method is configured to return <paramref name="expectedDefaultValueInStore"/>. Must be different 
+        ///                                                 from <paramref name="expectedAlternateValueProperty"/>. </param>
+        /// <param name="expectedDefaultValueInStore">      The <paramref name="defaultValueProperty"/> as it is expected to exist in the store.
+        ///                                                 Must be different from <paramref name="expectedAlternateValueInStore"/>. Used both to provide 
+        ///                                                 values from the store and confirm values written to the store. </param>
+        /// <param name="expectedAlternateValueProperty">   This is the expected value of the property after <c>Load</c> returns when the setting store get 
+        ///                                                 method is configured to return <paramref name="expectedAlternateValueInStore"/>. Must be 
+        ///                                                 different from <paramref name="defaultValueProperty"/>. </param>
+        /// <param name="expectedAlternateValueInStore">    The <paramref name="expectedAlternateValueProperty"/> as it is expected to exist in the store. 
+        ///                                                 Must be different from <paramref name="expectedDefaultValueInStore"/>. Used both to provide
+        ///                                                 values from the store and confirm values written to the store. </param>
+        /// <param name="overrideAssertEquality">           (Optional) If non-null, this will be used to assert equality of the value of the property after
+        ///                                                 <c>Load</c> operations rather than the standard assertions. Signature is <c>TestValueType valueBeingTested, 
+        ///                                                 TPropertyType expected, TPropertyType actual, string because</c> </param>
+        private void SettingStoreTest_String<TPropertyType, TOptMdl>(BaseOptionModel<TOptMdl> objUt, string collectionPath, string propertyName,
+            PropertyInfo propertyUt, Func<TPropertyType?> getProperty, Action<TPropertyType?> setProperty,
+            TPropertyType? defaultValueProperty, string expectedDefaultValueInStore,
+            TPropertyType? expectedAlternateValueProperty, string expectedAlternateValueInStore,
+            Action<TestValueType, TPropertyType?, TPropertyType?, string>? overrideAssertEquality = null)
+            where TOptMdl : BaseOptionModel<TOptMdl>, new()
+        {
+            Mock<WritableSettingsStore> mock = new();
+            mock.Setup(x => x.CollectionExists(collectionPath)).Returns(true);
+            mock.Setup(x => x.PropertyExists(collectionPath, propertyName)).Returns(true);
+
+            void SetupSettingsStoreGet(string valueToReturn)
+            {
+                mock.Setup(x => x.GetString(collectionPath, propertyName)).Returns(valueToReturn);
+            }
+
+            Action<int, string> verifyGet = (int callCount, string failMessage) =>
+                 mock.Verify(x => x.GetString(collectionPath, propertyName), Times.Exactly(callCount), failMessage);
+            Action<int, string, string> verifySet = (int callCount, string expectedValue, string failMessage) =>
+                mock.Verify(x => x.SetString(collectionPath, propertyName, expectedValue), Times.Exactly(callCount), failMessage);
+
+            SettingStoreTest(objUt, propertyUt, getProperty, setProperty, mock.Object, SetupSettingsStoreGet, verifyGet, verifySet,
+                             defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore, overrideAssertEquality);
+        }
+
+        /// <summary>   Helper Test Method, used for testing properties where the underlying <see cref="SettingsStore"/> type is 
+        ///             a <see cref="int"/>.</summary>
+        /// <typeparam name="TPropertyType">    The property type of the wrapped property, <paramref name="propertyUt"/>. </typeparam>
+        /// <typeparam name="TOptMdl">    The type of the base option model class that is the target object for the test. </typeparam>
+        /// <param name="objUt">                            An instance of the <see cref="BaseOptionModel{T}"/>, containing <paramref name="propertyUt"/>. </param>
+        /// <param name="collectionPath">                   The <c>collectionPath</c> that will be used when reading/writing to the settings store.. </param>
+        /// <param name="propertyName">                     The <c>propertyName</c> that will be used when reading/writing to the settings store. </param>
+        /// <param name="propertyUt">                       The property being wrapped for the test. </param>
+        /// <param name="getProperty">                      Delegate to get the property value (represented by <paramref name="propertyUt"/>) from <paramref name="objUt"/>. </param>
+        /// <param name="setProperty">                      Delegate to set the property (represented by <paramref name="propertyUt"/>) on <paramref name="objUt"/>. </param>
+        /// <param name="defaultValueProperty">             Prior to test, the property will be set to this value using <paramref name="setProperty"/>.
+        ///                                                 This is the expected value of the property after <c>Load</c> returns when the setting store get
+        ///                                                 method is configured to return <paramref name="expectedDefaultValueInStore"/>. Must be different 
+        ///                                                 from <paramref name="expectedAlternateValueProperty"/>. </param>
+        /// <param name="expectedDefaultValueInStore">      The <paramref name="defaultValueProperty"/> as it is expected to exist in the store.
+        ///                                                 Must be different from <paramref name="expectedAlternateValueInStore"/>. Used both to provide 
+        ///                                                 values from the store and confirm values written to the store. </param>
+        /// <param name="expectedAlternateValueProperty">   This is the expected value of the property after <c>Load</c> returns when the setting store get 
+        ///                                                 method is configured to return <paramref name="expectedAlternateValueInStore"/>. Must be 
+        ///                                                 different from <paramref name="defaultValueProperty"/>. </param>
+        /// <param name="expectedAlternateValueInStore">    The <paramref name="expectedAlternateValueProperty"/> as it is expected to exist in the store. 
+        ///                                                 Must be different from <paramref name="expectedDefaultValueInStore"/>. Used both to provide
+        ///                                                 values from the store and confirm values written to the store. </param>
+        private void SettingStoreTest_Int32<TPropertyType, TOptMdl>(BaseOptionModel<TOptMdl> objUt, string collectionPath, string propertyName,
+            PropertyInfo propertyUt, Func<TPropertyType?> getProperty, Action<TPropertyType?> setProperty,
+            TPropertyType? defaultValueProperty, int expectedDefaultValueInStore,
+            TPropertyType? expectedAlternateValueProperty, int expectedAlternateValueInStore)
+            where TOptMdl : BaseOptionModel<TOptMdl>, new()
+        {
+            Mock<WritableSettingsStore> mock = new();
+            mock.Setup(x => x.CollectionExists(collectionPath)).Returns(true);
+            mock.Setup(x => x.PropertyExists(collectionPath, propertyName)).Returns(true);
+            mock.Setup(x => x.SetInt32(collectionPath, propertyName, It.IsAny<int>()));
+
+            void SetupSettingsStoreGet(int valueToReturn)
+            {
+                mock.Setup(x => x.GetInt32(collectionPath, propertyName)).Returns(valueToReturn);
+            }
+
+            Action<int, string> verifyGet = (int callCount, string failMessage) =>
+                mock.Verify(x => x.GetInt32(collectionPath, propertyName), Times.Exactly(callCount), failMessage);
+            Action<int, int, string> verifySet = (int callCount, int expectedValue, string failMessage) =>
+                mock.Verify(x => x.SetInt32(collectionPath, propertyName, expectedValue), Times.Exactly(callCount), failMessage);
+
+            SettingStoreTest(objUt, propertyUt, getProperty, setProperty, mock.Object, SetupSettingsStoreGet, verifyGet, verifySet,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        /// <summary>   Helper Test Method, used for testing properties where the underlying <see cref="SettingsStore"/> type is 
+        ///             a <see cref="uint"/>.</summary>
+        /// <typeparam name="TPropertyType">    The property type of the wrapped property, <paramref name="propertyUt"/>. </typeparam>
+        /// <typeparam name="TOptMdl">    The type of the base option model class that is the target object for the test. </typeparam>
+        /// <param name="objUt">                            An instance of the <see cref="BaseOptionModel{T}"/>, containing <paramref name="propertyUt"/>. </param>
+        /// <param name="collectionPath">                   The <c>collectionPath</c> that will be used when reading/writing to the settings store.. </param>
+        /// <param name="propertyName">                     The <c>propertyName</c> that will be used when reading/writing to the settings store. </param>
+        /// <param name="propertyUt">                       The property being wrapped for the test. </param>
+        /// <param name="getProperty">                      Delegate to get the property value (represented by <paramref name="propertyUt"/>) from <paramref name="objUt"/>. </param>
+        /// <param name="setProperty">                      Delegate to set the property (represented by <paramref name="propertyUt"/>) on <paramref name="objUt"/>. </param>
+        /// <param name="defaultValueProperty">             Prior to test, the property will be set to this value using <paramref name="setProperty"/>.
+        ///                                                 This is the expected value of the property after <c>Load</c> returns when the setting store get
+        ///                                                 method is configured to return <paramref name="expectedDefaultValueInStore"/>. Must be different 
+        ///                                                 from <paramref name="expectedAlternateValueProperty"/>. </param>
+        /// <param name="expectedDefaultValueInStore">      The <paramref name="defaultValueProperty"/> as it is expected to exist in the store.
+        ///                                                 Must be different from <paramref name="expectedAlternateValueInStore"/>. Used both to provide 
+        ///                                                 values from the store and confirm values written to the store. </param>
+        /// <param name="expectedAlternateValueProperty">   This is the expected value of the property after <c>Load</c> returns when the setting store get 
+        ///                                                 method is configured to return <paramref name="expectedAlternateValueInStore"/>. Must be 
+        ///                                                 different from <paramref name="defaultValueProperty"/>. </param>
+        /// <param name="expectedAlternateValueInStore">    The <paramref name="expectedAlternateValueProperty"/> as it is expected to exist in the store. 
+        ///                                                 Must be different from <paramref name="expectedDefaultValueInStore"/>. Used both to provide
+        ///                                                 values from the store and confirm values written to the store. </param>
+        private void SettingStoreTest_UInt32<TPropertyType, TOptMdl>(BaseOptionModel<TOptMdl> objUt, string collectionPath, string propertyName,
+            PropertyInfo propertyUt, Func<TPropertyType?> getProperty, Action<TPropertyType?> setProperty,
+            TPropertyType? defaultValueProperty, uint expectedDefaultValueInStore,
+            TPropertyType? expectedAlternateValueProperty, uint expectedAlternateValueInStore)
+            where TOptMdl : BaseOptionModel<TOptMdl>, new()
+        {
+            Mock<WritableSettingsStore> mock = new();
+            mock.Setup(x => x.CollectionExists(collectionPath)).Returns(true);
+            mock.Setup(x => x.PropertyExists(collectionPath, propertyName)).Returns(true);
+            mock.Setup(x => x.SetUInt32(collectionPath, propertyName, It.IsAny<uint>()));
+
+            void SetupSettingsStoreGet(uint valueToReturn)
+            {
+                mock.Setup(x => x.GetUInt32(collectionPath, propertyName)).Returns(valueToReturn);
+            }
+
+            Action<int, string> verifyGet = (int callCount, string failMessage) =>
+                mock.Verify(x => x.GetUInt32(collectionPath, propertyName), Times.Exactly(callCount), failMessage);
+            Action<int, uint, string> verifySet = (int callCount, uint expectedValue, string failMessage) =>
+                mock.Verify(x => x.SetUInt32(collectionPath, propertyName, expectedValue), Times.Exactly(callCount), failMessage);
+
+            SettingStoreTest(objUt, propertyUt, getProperty, setProperty, mock.Object, SetupSettingsStoreGet, verifyGet, verifySet,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        /// <summary>   Helper Test Method, used for testing properties where the underlying <see cref="SettingsStore"/> type is 
+        ///             a <see cref="long"/>.</summary>
+        /// <typeparam name="TPropertyType">    The property type of the wrapped property, <paramref name="propertyUt"/>. </typeparam>
+        /// <typeparam name="TOptMdl">    The type of the base option model class that is the target object for the test. </typeparam>
+        /// <param name="objUt">                            An instance of the <see cref="BaseOptionModel{T}"/>, containing <paramref name="propertyUt"/>. </param>
+        /// <param name="collectionPath">                   The <c>collectionPath</c> that will be used when reading/writing to the settings store.. </param>
+        /// <param name="propertyName">                     The <c>propertyName</c> that will be used when reading/writing to the settings store. </param>
+        /// <param name="propertyUt">                       The property being wrapped for the test. </param>
+        /// <param name="getProperty">                      Delegate to get the property value (represented by <paramref name="propertyUt"/>) from <paramref name="objUt"/>. </param>
+        /// <param name="setProperty">                      Delegate to set the property (represented by <paramref name="propertyUt"/>) on <paramref name="objUt"/>. </param>
+        /// <param name="defaultValueProperty">             Prior to test, the property will be set to this value using <paramref name="setProperty"/>.
+        ///                                                 This is the expected value of the property after <c>Load</c> returns when the setting store get
+        ///                                                 method is configured to return <paramref name="expectedDefaultValueInStore"/>. Must be different 
+        ///                                                 from <paramref name="expectedAlternateValueProperty"/>. </param>
+        /// <param name="expectedDefaultValueInStore">      The <paramref name="defaultValueProperty"/> as it is expected to exist in the store.
+        ///                                                 Must be different from <paramref name="expectedAlternateValueInStore"/>. Used both to provide 
+        ///                                                 values from the store and confirm values written to the store. </param>
+        /// <param name="expectedAlternateValueProperty">   This is the expected value of the property after <c>Load</c> returns when the setting store get 
+        ///                                                 method is configured to return <paramref name="expectedAlternateValueInStore"/>. Must be 
+        ///                                                 different from <paramref name="defaultValueProperty"/>. </param>
+        /// <param name="expectedAlternateValueInStore">    The <paramref name="expectedAlternateValueProperty"/> as it is expected to exist in the store. 
+        ///                                                 Must be different from <paramref name="expectedDefaultValueInStore"/>. Used both to provide
+        ///                                                 values from the store and confirm values written to the store. </param>
+        private void SettingStoreTest_Int64<TPropertyType, TOptMdl>(BaseOptionModel<TOptMdl> objUt, string collectionPath, string propertyName,
+            PropertyInfo propertyUt, Func<TPropertyType?> getProperty, Action<TPropertyType?> setProperty,
+            TPropertyType? defaultValueProperty, long expectedDefaultValueInStore,
+            TPropertyType? expectedAlternateValueProperty, long expectedAlternateValueInStore)
+            where TOptMdl : BaseOptionModel<TOptMdl>, new()
+        {
+            Mock<WritableSettingsStore> mock = new();
+            mock.Setup(x => x.CollectionExists(collectionPath)).Returns(true);
+            mock.Setup(x => x.PropertyExists(collectionPath, propertyName)).Returns(true);
+            mock.Setup(x => x.SetInt64(collectionPath, propertyName, It.IsAny<long>()));
+
+            void SetupSettingsStoreGet(long valueToReturn)
+            {
+                mock.Setup(x => x.GetInt64(collectionPath, propertyName)).Returns(valueToReturn);
+            }
+
+            Action<int, string> verifyGet = (int callCount, string failMessage) =>
+                mock.Verify(x => x.GetInt64(collectionPath, propertyName), Times.Exactly(callCount), failMessage);
+            Action<int, long, string> verifySet = (int callCount, long expectedValue, string failMessage) =>
+                mock.Verify(x => x.SetInt64(collectionPath, propertyName, expectedValue), Times.Exactly(callCount), failMessage);
+
+            SettingStoreTest(objUt, propertyUt, getProperty, setProperty, mock.Object, SetupSettingsStoreGet, verifyGet, verifySet,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        /// <summary>   Helper Test Method, used for testing properties where the underlying <see cref="SettingsStore"/> type is 
+        ///             a <see cref="ulong"/>.</summary>
+        /// <typeparam name="TPropertyType">    The property type of the wrapped property, <paramref name="propertyUt"/>. </typeparam>
+        /// <typeparam name="TOptMdl">    The type of the base option model class that is the target object for the test. </typeparam>
+        /// <param name="objUt">                            An instance of the <see cref="BaseOptionModel{T}"/>, containing <paramref name="propertyUt"/>. </param>
+        /// <param name="collectionPath">                   The <c>collectionPath</c> that will be used when reading/writing to the settings store.. </param>
+        /// <param name="propertyName">                     The <c>propertyName</c> that will be used when reading/writing to the settings store. </param>
+        /// <param name="propertyUt">                       The property being wrapped for the test. </param>
+        /// <param name="getProperty">                      Delegate to get the property value (represented by <paramref name="propertyUt"/>) from <paramref name="objUt"/>. </param>
+        /// <param name="setProperty">                      Delegate to set the property (represented by <paramref name="propertyUt"/>) on <paramref name="objUt"/>. </param>
+        /// <param name="defaultValueProperty">             Prior to test, the property will be set to this value using <paramref name="setProperty"/>.
+        ///                                                 This is the expected value of the property after <c>Load</c> returns when the setting store get
+        ///                                                 method is configured to return <paramref name="expectedDefaultValueInStore"/>. Must be different 
+        ///                                                 from <paramref name="expectedAlternateValueProperty"/>. </param>
+        /// <param name="expectedDefaultValueInStore">      The <paramref name="defaultValueProperty"/> as it is expected to exist in the store.
+        ///                                                 Must be different from <paramref name="expectedAlternateValueInStore"/>. Used both to provide 
+        ///                                                 values from the store and confirm values written to the store. </param>
+        /// <param name="expectedAlternateValueProperty">   This is the expected value of the property after <c>Load</c> returns when the setting store get 
+        ///                                                 method is configured to return <paramref name="expectedAlternateValueInStore"/>. Must be 
+        ///                                                 different from <paramref name="defaultValueProperty"/>. </param>
+        /// <param name="expectedAlternateValueInStore">    The <paramref name="expectedAlternateValueProperty"/> as it is expected to exist in the store. 
+        ///                                                 Must be different from <paramref name="expectedDefaultValueInStore"/>. Used both to provide
+        ///                                                 values from the store and confirm values written to the store. </param>
+        private void SettingStoreTest_UInt64<TPropertyType, TOptMdl>(BaseOptionModel<TOptMdl> objUt, string collectionPath, string propertyName,
+            PropertyInfo propertyUt, Func<TPropertyType?> getProperty, Action<TPropertyType?> setProperty,
+            TPropertyType? defaultValueProperty, ulong expectedDefaultValueInStore,
+            TPropertyType? expectedAlternateValueProperty, ulong expectedAlternateValueInStore)
+            where TOptMdl : BaseOptionModel<TOptMdl>, new()
+        {
+            Mock<WritableSettingsStore> mock = new();
+            mock.Setup(x => x.CollectionExists(collectionPath)).Returns(true);
+            mock.Setup(x => x.PropertyExists(collectionPath, propertyName)).Returns(true);
+            mock.Setup(x => x.SetUInt64(collectionPath, propertyName, It.IsAny<ulong>()));
+
+            void SetupSettingsStoreGet(ulong valueToReturn)
+            {
+                mock.Setup(x => x.GetUInt64(collectionPath, propertyName)).Returns(valueToReturn);
+            }
+
+            Action<int, string> verifyGet = (int callCount, string failMessage) =>
+                mock.Verify(x => x.GetUInt64(collectionPath, propertyName), Times.Exactly(callCount), failMessage);
+            Action<int, ulong, string> verifySet = (int callCount, ulong expectedValue, string failMessage) =>
+                mock.Verify(x => x.SetUInt64(collectionPath, propertyName, expectedValue), Times.Exactly(callCount), failMessage);
+
+            SettingStoreTest(objUt, propertyUt, getProperty, setProperty, mock.Object, SetupSettingsStoreGet, verifyGet, verifySet,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore);
+        }
+
+        /// <summary>   Helper Test Method, used for testing properties where the underlying <see cref="SettingsStore"/> type is 
+        ///             a <see cref="MemoryStream"/>.</summary>
+        /// <typeparam name="TPropertyType">    The property type of the wrapped property, <paramref name="propertyUt"/>. </typeparam>
+        /// <typeparam name="TOptMdl">    The type of the base option model class that is the target object for the test. </typeparam>
+        /// <param name="objUt">                            An instance of the <see cref="BaseOptionModel{T}"/>, containing <paramref name="propertyUt"/>. </param>
+        /// <param name="collectionPath">                   The <c>collectionPath</c> that will be used when reading/writing to the settings store.. </param>
+        /// <param name="propertyName">                     The <c>propertyName</c> that will be used when reading/writing to the settings store. </param>
+        /// <param name="propertyUt">                       The property being wrapped for the test. </param>
+        /// <param name="getProperty">                      Delegate to get the property value (represented by <paramref name="propertyUt"/>) from <paramref name="objUt"/>. </param>
+        /// <param name="setProperty">                      Delegate to set the property (represented by <paramref name="propertyUt"/>) on <paramref name="objUt"/>. </param>
+        /// <param name="defaultValueProperty">             Prior to test, the property will be set to this value using <paramref name="setProperty"/>.
+        ///                                                 This is the expected value of the property after <c>Load</c> returns when the setting store get
+        ///                                                 method is configured to return <paramref name="expectedDefaultValueInStore"/>. Must be different 
+        ///                                                 from <paramref name="expectedAlternateValueProperty"/>. </param>
+        /// <param name="expectedDefaultValueInStore">      The <paramref name="defaultValueProperty"/> as it is expected to exist in the store.
+        ///                                                 Must be different from <paramref name="expectedAlternateValueInStore"/>. Used both to provide 
+        ///                                                 values from the store and confirm values written to the store. </param>
+        /// <param name="expectedAlternateValueProperty">   This is the expected value of the property after <c>Load</c> returns when the setting store get 
+        ///                                                 method is configured to return <paramref name="expectedAlternateValueInStore"/>. Must be 
+        ///                                                 different from <paramref name="defaultValueProperty"/>. </param>
+        /// <param name="expectedAlternateValueInStore">    The <paramref name="expectedAlternateValueProperty"/> as it is expected to exist in the store. 
+        ///                                                 Must be different from <paramref name="expectedDefaultValueInStore"/>. Used both to provide
+        ///                                                 values from the store and confirm values written to the store. </param>
+        /// <param name="overrideAssertEquality">           (Optional) If non-null, this will be used to assert equality of the value of the property after
+        ///                                                 <c>Load</c> operations rather than the standard assertions. Signature is <c>TestValueType valueBeingTested, 
+        ///                                                 TPropertyType expected, TPropertyType actual, string because</c> </param>
+        private void SettingStoreTest_MemoryStream<TPropertyType, TOptMdl>(BaseOptionModel<TOptMdl> objUt, string collectionPath, string propertyName,
+            PropertyInfo propertyUt, Func<TPropertyType?> getProperty, Action<TPropertyType?> setProperty,
+            TPropertyType? defaultValueProperty, byte[] expectedDefaultValueInStore,
+            TPropertyType? expectedAlternateValueProperty, byte[] expectedAlternateValueInStore,
+            Action<TestValueType, TPropertyType?, TPropertyType?, string>? overrideAssertEquality = null)
+            where TOptMdl : BaseOptionModel<TOptMdl>, new()
+        {
+            Mock<WritableSettingsStore> mock = new();
+            mock.Setup(x => x.CollectionExists(collectionPath)).Returns(true);
+            mock.Setup(x => x.PropertyExists(collectionPath, propertyName)).Returns(true);
+
+            List<byte[]?> setInvocations = new();
+            mock.Setup(x => x.SetMemoryStream(collectionPath, propertyName, It.IsAny<MemoryStream>())).Callback((string _, string __, MemoryStream stream) =>
+            {
+                if (stream == null)
+                    setInvocations.Add(null);
+                else
+                    setInvocations.Add(stream.ToArray());
+            });
+
+            void SetupSettingsStoreGet(byte[] valueToReturn)
+            {
+                mock.Setup(x => x.GetMemoryStream(collectionPath, propertyName)).Returns(new MemoryStream(valueToReturn));
+            }
+
+            void VerifyGet(int callCount, string failMessage)
+            {
+                mock.Verify(x => x.GetMemoryStream(collectionPath, propertyName), Times.Exactly(callCount), failMessage);
+            }
+
+            void VerifySet(int callCount, byte[] expectedValue, string because)
+            {
+                int matchingCount = 0;
+                foreach (byte[]? buffer in setInvocations)
+                {
+                    if (buffer == null && expectedValue == null)
+                        matchingCount++;
+                    else if (buffer == null || expectedValue == null)
+                        continue;
+                    else if (buffer.SequenceEqual(expectedValue))
+                        matchingCount++;
+                }
+                callCount.Should().Be(matchingCount, because);
+            }
+
+            _output.WriteLine("expectedDefaultValueInStore (as string): {0}", System.Text.Encoding.UTF8.GetString(expectedDefaultValueInStore));
+            _output.WriteLine("expectedAlternateValueInStore (as string): {0}", System.Text.Encoding.UTF8.GetString(expectedAlternateValueInStore));
+
+            SettingStoreTest(objUt, propertyUt, getProperty, setProperty, mock.Object, SetupSettingsStoreGet, VerifyGet, VerifySet,
+                defaultValueProperty, expectedDefaultValueInStore, expectedAlternateValueProperty, expectedAlternateValueInStore, overrideAssertEquality);
+        }
+
+        /// <summary>   Main Test Method. Used by the helper methods that are based around setting up the mocks for the <paramref name="settingsStore"/>.  </summary>
+        /// <typeparam name="TPropertyType">    The property type of the wrapped property, <paramref name="propertyUt"/>. </typeparam>
+        /// <typeparam name="TStorageType">    The native storage type used in the settings store. </typeparam>
+        /// <typeparam name="TOptMdl">    The type of the base option model class that is the target object for the test. </typeparam>
+        /// <param name="objUt">                            An instance of the <see cref="BaseOptionModel{T}"/>, containing <paramref name="propertyUt"/>. </param>
+        /// <param name="propertyUt">                       The property being wrapped for the test. </param>
+        /// <param name="getProperty">                      Delegate to get the property value (represented by <paramref name="propertyUt"/>) from <paramref name="objUt"/>. </param>
+        /// <param name="setProperty">                      Delegate to set the property (represented by <paramref name="propertyUt"/>) on <paramref name="objUt"/>. </param>
+        /// <param name="settingsStore">                    The mock for the <see cref="WritableSettingsStore"/>. </param>
+        /// <param name="setupSettingsStoreGet">            Method to configure the settings store to return the provided value when the get method on the <paramref name="settingsStore"/> is
+        ///                                                 called with the expected parameters. Signature is <c>TStorageType valueToReturn</c> </param>
+        /// <param name="verifySettingsStoreGetWasCalled">  Method to assert the settings store get method on the <paramref name="settingsStore"/> was
+        ///                                                 called. Signature is <c>int expectedCallCount, string because</c>. </param>
+        /// <param name="verifySettingsStoreSetWasCalled">  Method to assert the settings store set method on the <paramref name="settingsStore"/> was 
+        ///                                                 called with the expected parameters. Signature is <c>int expectedCallCount, TStorageType expectedValue, string because</c> </param>
+        /// <param name="defaultValueProperty">             Prior to test, the property will be set to this value using <paramref name="setProperty"/>.
+        ///                                                 This is the expected value of the property after <c>Load</c> returns when the setting store get
+        ///                                                 method is configured to return <paramref name="expectedDefaultValueInStore"/>. Must be different 
+        ///                                                 from <paramref name="expectedAlternateValueProperty"/>. </param>
+        /// <param name="expectedDefaultValueInStore">      The <paramref name="defaultValueProperty"/> as it is expected to exist in the store.
+        ///                                                 Must be different from <paramref name="expectedAlternateValueInStore"/>. Used both to provide 
+        ///                                                 values from the store and confirm values written to the store. </param>
+        /// <param name="expectedAlternateValueProperty">   This is the expected value of the property after <c>Load</c> returns when the setting store get 
+        ///                                                 method is configured to return <paramref name="expectedAlternateValueInStore"/>. Must be 
+        ///                                                 different from <paramref name="defaultValueProperty"/>. </param>
+        /// <param name="expectedAlternateValueInStore">    The <paramref name="expectedAlternateValueProperty"/> as it is expected to exist in the store. 
+        ///                                                 Must be different from <paramref name="expectedDefaultValueInStore"/>. Used both to provide
+        ///                                                 values from the store and confirm values written to the store. </param>
+        /// <param name="overrideAssertEquality">           (Optional) If non-null, this will be used to assert equality of the value of the property after
+        ///                                                 <c>Load</c> operations rather than the standard assertions. Signature is <c>TestValueType valueBeingTested, 
+        ///                                                 TPropertyType expected, TPropertyType actual, string because</c> </param>
+        private void SettingStoreTest<TPropertyType, TStorageType, TOptMdl>(BaseOptionModel<TOptMdl> objUt, PropertyInfo propertyUt, Func<TPropertyType?> getProperty, Action<TPropertyType?> setProperty,
+                            WritableSettingsStore settingsStore, Action<TStorageType> setupSettingsStoreGet, Action<int, string> verifySettingsStoreGetWasCalled, Action<int, TStorageType, string> verifySettingsStoreSetWasCalled,
+                            TPropertyType? defaultValueProperty, TStorageType expectedDefaultValueInStore,
+                            TPropertyType? expectedAlternateValueProperty, TStorageType expectedAlternateValueInStore,
+                            Action<TestValueType, TPropertyType?, TPropertyType?, string>? overrideAssertEquality = null)
+                            where TOptMdl : BaseOptionModel<TOptMdl>, new()
+        {
+            objUt.Should().NotBeNull("because we need an object that is the target for the test");
+            propertyUt.Should().NotBeNull("because we need a property info to wrap for the test");
+            propertyUt.PropertyType.Should().Be<TPropertyType>("because the type of the property we are testing should match the type of the property values we are testing.");
+            propertyUt.DeclaringType.Should().BeAssignableTo<BaseOptionModel<TOptMdl>>("because the type of the property we are testing should belong to the object being tested.");
+            OptionModelPropertyWrapper uut = new(propertyUt);
+
+            expectedDefaultValueInStore.Should().NotBeEquivalentTo(expectedAlternateValueInStore,
+                "because for the test to be valid, the default and loaded value in setting store should be different.");
+
+            defaultValueProperty.Should().NotBeEquivalentTo(expectedAlternateValueProperty,
+                "because for the test to be valid, the default and loaded value of the property should be different.");
+
+            setProperty(defaultValueProperty);
+
+            // Test save of default value
+            bool saveMethodResult = uut.Save(objUt, settingsStore);
+            verifySettingsStoreSetWasCalled(1, expectedDefaultValueInStore, "because Save with the defaultValueProperty should result" +
+                                                                            "in the settings store set method being called with expectedDefaultValueInStore");
+            saveMethodResult.Should().BeTrue("because we expect Save to return true for saving default value to store.");
+
+            // Test Load process for alternate value. Verify property value is changed. Verify expected Settings Store Get method was called.
+            setupSettingsStoreGet(expectedAlternateValueInStore);
+            bool loadMethodResult = uut.Load(objUt, settingsStore);
+
+            string propertyValueLoadMismatchBecause = "because Load should have set the property to the expectedAlternateValueProperty";
+            TPropertyType? actualPropertyValue = getProperty();
+            if (overrideAssertEquality == null)
+                actualPropertyValue.Should().BeEquivalentTo(expectedAlternateValueProperty, propertyValueLoadMismatchBecause);
+            else
+                overrideAssertEquality(TestValueType.Alternate, expectedAlternateValueProperty, actualPropertyValue, propertyValueLoadMismatchBecause);
+            loadMethodResult.Should().BeTrue("because we expect Load of the alternate value to report success when the property was successfully set.");
+            verifySettingsStoreGetWasCalled(1, "because the proper Settings Store Get method should be called during load for the alternate value.");
+
+            // Test save process. Verify expected Settings Store Set method was called with proper value.
+            saveMethodResult = uut.Save(objUt, settingsStore);
+            verifySettingsStoreSetWasCalled(1, expectedAlternateValueInStore, "because Save with the expectedAlternateValueProperty should result" +
+                                                                              "in the settings store set method being called with expectedAlternateValueInStore");
+            saveMethodResult.Should().BeTrue("because we expect Save to return true for saving alternate value to store.");
+
+            // Test load process for the default value
+            setupSettingsStoreGet(expectedDefaultValueInStore);
+            loadMethodResult = uut.Load(objUt, settingsStore);
+
+            propertyValueLoadMismatchBecause = "because Load should have set the property to the defaultValueProperty";
+            actualPropertyValue = getProperty();
+            if (overrideAssertEquality == null)
+                actualPropertyValue.Should().BeEquivalentTo(defaultValueProperty, propertyValueLoadMismatchBecause);
+            else
+                overrideAssertEquality(TestValueType.Default, defaultValueProperty, actualPropertyValue, propertyValueLoadMismatchBecause);
+            verifySettingsStoreGetWasCalled(2, "because the proper Settings Store Get method should be called again during load for the default value.");
+            loadMethodResult.Should().BeTrue("because we expect Load of the default value to report success when the property was successfully set.");
+        }
+
+        #endregion Test Helper Methods and Main Test Method
+
+        #region BaseOptionModel under test
+
+        public class TestBom : BaseOptionModel<TestBom>
+        {
+            /// <inheritdoc />
+            protected internal override string CollectionName => TestCollectionName;
+
+            /// <summary>   Stored as string. </summary>
+            public string? String { get; set; }
+
+            /// <summary>   Stored as string. </summary>
+            public float Float { get; set; }
+
+            /// <summary>   Stored as string. </summary>
+            public double Double { get; set; }
+
+            /// <summary>   Stored as string. </summary>
+            public decimal Decimal { get; set; }
+
+            /// <summary>   Stored as string. </summary>
+            public char Char { get; set; }
+
+            /// <summary>   Stored as string. </summary>
+            public Guid Guid { get; set; }
+
+            /// <summary>   Stored as string. </summary>
+            public DateTimeOffset DateTimeOffset { get; set; }
+
+            /// <summary>   Stored as int. </summary>
+            public bool Bool { get; set; }
+
+            /// <summary>   Stored as int. </summary>
+            public sbyte SByte { get; set; }
+
+            /// <summary>   Stored as int. </summary>
+            public byte Byte { get; set; }
+
+            /// <summary>   Stored as int. </summary>
+            public short Short { get; set; }
+
+            /// <summary>   Stored as int. </summary>
+            public ushort UShort { get; set; }
+
+            /// <summary>   Stored as int. </summary>
+            public int Int { get; set; }
+
+            /// <summary>   Stored as int. </summary>
+            [OverridePropertyName(OverridePropertyName)]
+            public int IntPropertyName { get; set; }
+
+            /// <summary>   Stored as int. </summary>
+            [OverrideCollectionName(OverrideCollectionName)]
+            public int IntCollectionName { get; set; }
+
+            /// <summary>   Stored as int. </summary>
+            public Color Color { get; set; }
+
+            /// <summary>   Stored as uint. </summary>
+            public uint UInt { get; set; }
+
+            /// <summary>   Stored as long. </summary>
+            public long Long { get; set; }
+
+            /// <summary>   Stored as long. </summary>
+            public DateTime DateTime { get; set; }
+
+            /// <summary>   Stored as ulong. </summary>
+            public ulong ULong { get; set; }
+
+            /// <summary>   Stored as MemoryStream. </summary>
+            public byte[]? ByteArray { get; set; }
+
+            /// <summary>   Stored as int. </summary>
+            public NativeSettingsType Enumeration { get; set; }
+
+            /// <summary>   Stored as UInt64. (OverrideDataType to UInt64) </summary>
+            [OverrideDataType(SettingDataType.UInt64)]
+            public bool BoolStoredAsUInt64 { get; set; }
+
+            /// <summary>   Stored as xml serialized string. </summary>
+            public CustomType? CustomType { get; set; }
+
+            /// <summary>   Stored as string. </summary>
+            [OverrideDataType(SettingDataType.String, true)]
+            public CustomType? CustomType_TypeConverterString { get; set; }
+
+            /// <summary>   Stored as binary. </summary>
+            [OverrideDataType(SettingDataType.Binary, true)]
+            public CustomType? CustomType_TypeConverterBinary { get; set; }
+
+            /// <summary>   Stored as xml serialized binary. </summary>
+            public List<string>? ListOfString { get; set; }
+
+            /// <summary>   Stored as xml serialized binary. </summary>
+            [OverrideDataType(SettingDataType.Legacy)]
+            public List<string>? ListOfStringLegacy { get; set; }
+        }
+        #endregion BaseOptionModel under test
+
+    }
+
+    [TypeConverter(typeof(CustomTypeConverter))]
+    public class CustomType
+    {
+        public string? StringValue { get; set; }
+    }
+
+    /// <summary>   Supports byte[] and string conversions </summary>
+    public class CustomTypeConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(byte[]) || sourceType == typeof(string);
+        }
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return destinationType == typeof(byte[]) || destinationType == typeof(string);
+        }
+
+        public override object? ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is string stringValue)
+                return FromString(stringValue);
+
+            if (value is byte[] byteValue)
+            {
+                string tempStr = Encoding.UTF8.GetString(byteValue);
+                return FromString(tempStr);
+            }
+            throw new NotSupportedException($"Cannot convert CustomType from {value?.GetType().FullName ?? "[Null Value]"}");
+        }
+
+        public override object? ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            CustomType? customType = value as CustomType;
+            if (value != null && customType == null)
+                throw new NotSupportedException($"Cannot convert objects of type {value.GetType().FullName} to anything");
+
+            if (destinationType == typeof(string))
+                return ToString(customType);
+
+            if (destinationType == typeof(byte[]))
+            {
+                var tmpStr = ToString(customType);
+                return Encoding.UTF8.GetBytes(tmpStr);
+            }
+
+            throw new NotSupportedException($"Cannot convert to type {destinationType.FullName}.");
+        }
+
+        private string ToString(CustomType? customType)
+        {
+            if (customType == null)
+                return string.Empty;
+            if (customType.StringValue == null)
+                return "\0";
+            return customType.StringValue;
+        }
+
+        private CustomType? FromString(string stringValue)
+        {
+            if (stringValue.Length == 0)
+                return null;
+            if (stringValue.Length == 1 && stringValue[0] == '\0')
+                return new CustomType();
+            return new CustomType() { StringValue = stringValue };
+        }
+    }
+
+}

--- a/test/VSSDK.TestExtension/Options/General.cs
+++ b/test/VSSDK.TestExtension/Options/General.cs
@@ -1,4 +1,7 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Globalization;
 using Community.VisualStudio.Toolkit;
 using Microsoft.VisualStudio.Shell;
 
@@ -19,6 +22,34 @@ namespace TestExtension
         [Description("An informative description.")]
         [DefaultValue(true)]
         public bool MyOption { get; set; } = true;
+
+        [Category("My category")]
+        [DisplayName("String Value")]
+        [Description("This is a string.")]
+        [DefaultValue("Default")]
+        public string MyString { get; set; } = "Default";
+
+        [Category("My category")]
+        [DisplayName("List of Strings")]
+        [Description("This is a list of strings.")]
+        public string[] MyListOfStrings { get; set; } = new string[0];
+
+        [Category("My category")]
+        [DisplayName("Color Value")]
+        [Description("My Favorite Color")]
+        public Color FavoriteColor { get; set; } = Color.Purple;
+
+        [Category("My category")]
+        [DisplayName("Comparison Method")]
+        [Description("How to Compare Apples and Oranges")]
+        [DefaultValue("IgnoreKanaType")]
+        public CompareOptions MyComparisonMethod { get; set; } = CompareOptions.IgnoreKanaType;
+
+        [Category("My category")]
+        [DisplayName("MyBirthday")]
+        [Description("When the Toolkit was Born")]
+        [DefaultValue("2021-04-11")]
+        public DateTime MyBirthday { get; set; } = new DateTime(2021, 04, 11);
 
         public General() : base()
         {


### PR DESCRIPTION
- Types supported: [Integral numeric types except for nint and nuint](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types), all enumeration types (via underlying type), bool, float, double, decimal, char, string, DateTime, DateTimeOffset, Color, and Guid.
- Types with caveats: string (null becomes string.empty), byte[] and MemoryStream which if null become empty byte arrays.
- Special Handling: Color, Guid, DateTime, DateTimeOffset, float, and double are handled specially to assure they round-trip. Convert.ChangeType is used for the remainder of the types, if the type is not already an exact match for the settings store.
- For other types, for example string[], the default serialization is now using XmlSerializer rather than BinarySerializer, which supports round-tripping null as empty string.
- Reflection on each property is performed once per options type (static) on the first load or save call. The reflection process creates open delegates that are used to get/set property values and the settings store.
- Retained ability to opt in to override collection name, property name, and storage type, including ability to use TypeConverter.
- Added unit test project, covering all mentioned above, using xUnit, Moq, and FluentAssertions.
- Added additional sample types to the TestExtension options (Color, enum, string[], string, DateTime)

As discussed, this is a breaking change, and settings stored with previous versions of the toolkit will log an error when Load is called for each setting, essentially reverting to the object's default values. Once Save is called, the native storage mechanism will overwrite the old settings with the proper type and no more errors will be seen.