### PR TITLE
ProgressBar styles

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/Themes/ThemeResources.xaml
+++ b/src/Community.VisualStudio.Toolkit.Shared/Themes/ThemeResources.xaml
@@ -4,9 +4,14 @@
     xmlns:local="clr-namespace:Community.VisualStudio.Toolkit;assembly=Community.VisualStudio.Toolkit"
     xmlns:shell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
     xmlns:platform="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+    xmlns:system="clr-namespace:System;assembly=mscorlib"
     >
 
+    <!-- This is the same padding used by WatermarkedTextBox. -->
     <Thickness x:Key="{x:Static local:ToolkitResourceKeys.InputPaddingKey}">6,8,6,8</Thickness>
+    
+    <!-- This is the same height used in the IVsThreadedWaitDialog. -->
+    <system:Double x:Key="{x:Static local:ToolkitResourceKeys.ThickProgressBarHeight}">16</system:Double>
 
     <Style TargetType="TextBox" BasedOn="{StaticResource {x:Static shell:VsResourceKeys.TextBoxStyleKey}}">
         <Setter Property="Padding" Value="{StaticResource {x:Static local:ToolkitResourceKeys.InputPaddingKey}}" />
@@ -49,7 +54,7 @@
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static platform:CommonControlsColors.TextBoxTextBrushKey}}" />
                 <Setter Property="BorderBrush" Value="{DynamicResource {x:Static platform:CommonControlsColors.TextBoxBorderBrushKey}}" />
             </Trigger>
-            
+
             <Trigger Property="IsFocused" Value="True">
                 <Setter Property="Background" Value="{DynamicResource {x:Static platform:CommonControlsColors.TextBoxBackgroundFocusedBrushKey}}" />
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static platform:CommonControlsColors.TextBoxTextFocusedBrushKey}}" />

--- a/src/Community.VisualStudio.Toolkit.Shared/Themes/ToolkitResourceKeys.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Themes/ToolkitResourceKeys.cs
@@ -1,11 +1,20 @@
 ﻿using System.Windows;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Community.VisualStudio.Toolkit
 {
     /// <summary>Exposes WPF resource keys for WPF controls.</summary>
     public static class ToolkitResourceKeys
     {
+        private const string _prefix = "Toolkit";
+
         /// <summary>Gets the key that can be used to get the <see cref="Thickness"/> to use for input controls.</summary>
-        public static object InputPaddingKey { get; } = "Toolkit" + nameof(InputPaddingKey);
+        public static object InputPaddingKey { get; } = _prefix + nameof(InputPaddingKey);
+
+        /// <summary>
+        /// Gets the key that can be used to get the <see cref="double"/> to use for a progress bar with a thick height
+        /// (similar to the height used in the <see cref="IVsThreadedWaitDialog"/>).
+        /// </summary>
+        public static object ThickProgressBarHeight { get; } = _prefix + nameof(ThickProgressBarHeight);
     }
 }

--- a/test/VSSDK.TestExtension/ToolWindows/ThemeWindow/ThemeWindowDemo.xaml
+++ b/test/VSSDK.TestExtension/ToolWindows/ThemeWindow/ThemeWindowDemo.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl 
+<UserControl 
     x:Class="TestExtension.ThemeWindowDemo"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -15,17 +15,17 @@
     <UserControl.Resources>
         <!-- Uncomment the line below to override the padding used in TextBox and ComboBox controls. -->
         <!--<Thickness x:Key="{x:Static toolkit:ToolkitResourceKeys.InputPaddingKey}">1,1,1,1</Thickness>-->
-        
+
         <Thickness x:Key="SmallMargin">0,0,0,5</Thickness>
     </UserControl.Resources>
-    
+
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="10" Orientation="Vertical" Grid.IsSharedSizeScope="True">
             <local:ThemedControl Label="Label:">
                 <local:ThemedControl.Enabled>
                     <Label>Enabled</Label>
                 </local:ThemedControl.Enabled>
-                
+
                 <local:ThemedControl.Disabled>
                     <Label IsEnabled="False">Disabled</Label>
                 </local:ThemedControl.Disabled>
@@ -143,6 +143,22 @@
                 <local:ThemedControl.Disabled>
                     <ListBox Height="80" IsEnabled="False" ItemsSource="{Binding ListItems}" />
                 </local:ThemedControl.Disabled>
+            </local:ThemedControl>
+
+            <local:ThemedControl Label="SmoothProgressBar:" DataContext="{Binding RelativeSource={RelativeSource AncestorType=local:ThemeWindowDemo}}">
+                <local:ThemedControl.Enabled>
+                    <StackPanel Orientation="Vertical">
+                        <platform:SmoothProgressBar ToolTip="Normal" Minimum="0" Maximum="100" Value="{Binding Progress}" Margin="{StaticResource SmallMargin}"/>
+                        <platform:SmoothProgressBar ToolTip="IsIndeterminate=True" IsIndeterminate="True" Margin="{StaticResource SmallMargin}"/>
+                        <platform:SmoothProgressBar ToolTip="ToolkitResourceKeys.ThickProgressBarHeight" Minimum="0" Maximum="100" Value="{Binding Progress}" Height="{DynamicResource {x:Static toolkit:ToolkitResourceKeys.ThickProgressBarHeight}}"/>
+                    </StackPanel>
+                </local:ThemedControl.Enabled>
+            </local:ThemedControl>
+
+            <local:ThemedControl Label="MarchingAntsProgressBar:">
+                <local:ThemedControl.Enabled>
+                    <platform:MarchingAntsProgressBar/>
+                </local:ThemedControl.Enabled>
             </local:ThemedControl>
 
             <local:ThemedControl Label="InputPaddingKey:">

--- a/test/VSSDK.TestExtension/ToolWindows/ThemeWindow/ThemeWindowDemo.xaml.cs
+++ b/test/VSSDK.TestExtension/ToolWindows/ThemeWindow/ThemeWindowDemo.xaml.cs
@@ -1,13 +1,29 @@
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using System.Windows.Controls;
+using Microsoft.VisualStudio.Shell;
 
 namespace TestExtension
 {
-    public partial class ThemeWindowDemo : UserControl
+    public partial class ThemeWindowDemo : UserControl, INotifyPropertyChanged
     {
+        private double _progress;
+
         public ThemeWindowDemo()
         {
             InitializeComponent();
+            UpdateProgressAsync().FireAndForget();
+        }
+
+        private async Task UpdateProgressAsync()
+        {
+            while (true)
+            {
+                await Task.Delay(250).ConfigureAwait(true);
+                Progress = (Progress + 5) % 101;
+            }
         }
 
         public IEnumerable<string> ListItems { get; } = new string[] {
@@ -17,7 +33,27 @@ namespace TestExtension
                 "Fourth",
                 "Fifth",
                 "Sixth"
-       };
+        };
 
+        public double Progress
+        {
+            get
+            {
+                return _progress;
+            }
+            set
+            {
+                _progress = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        private void RaisePropertyChanged([CallerMemberName] string name = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
     }
 }


### PR DESCRIPTION
Relates to #106.

There's a `Microsoft.VisualStudio.PlatformUI.SmoothProgressBar` which is already themed, so it seems like a better choice than a regular `ProgressBar`. No theming is needed, but the default height is thin (similar to what you see when searching in Solution Explorer), so I've added a resource that you can use to give it a thicker height if you want it to be like the progress bar in the `IVsThreadedWaitDialog`.