### PR TITLE
Update .editorconfig to display errors when using the 'var' keyword instead of explicit types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -73,9 +73,9 @@ dotnet_naming_style.start_underscore_style.required_prefix      = _
 # CSharp code style settings:
 [*.cs]
 # Prefer "var" everywhere
-csharp_style_var_for_built_in_types                   =false:suggestion
-csharp_style_var_when_type_is_apparent                =false:suggestion
-csharp_style_var_elsewhere                            = false : suggestion
+csharp_style_var_for_built_in_types                   =false:error
+csharp_style_var_when_type_is_apparent                =false:error
+csharp_style_var_elsewhere                            =false:error
 
 # Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods                = false : none

--- a/src/Community.VisualStudio.Toolkit.Shared/Options/BaseOptionModel.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Options/BaseOptionModel.cs
@@ -123,7 +123,7 @@ namespace Community.VisualStudio.Toolkit
             SettingsScope scope = SettingsScope.UserSettings;
             SettingsStore settingsStore = manager.GetReadOnlySettingsStore(scope);
 
-            foreach (var propertyWrapper in GetPropertyWrappers())
+            foreach (IOptionModelPropertyWrapper? propertyWrapper in GetPropertyWrappers())
             {
                 propertyWrapper.Load(this, settingsStore);
             }
@@ -148,7 +148,7 @@ namespace Community.VisualStudio.Toolkit
             SettingsScope scope = SettingsScope.UserSettings;
             WritableSettingsStore settingsStore = manager.GetWritableSettingsStore(scope);
 
-            foreach (var propertyWrapper in GetPropertyWrappers())
+            foreach (IOptionModelPropertyWrapper? propertyWrapper in GetPropertyWrappers())
             {
                 propertyWrapper.Save(this, settingsStore);
             }

--- a/src/Community.VisualStudio.Toolkit.UnitTests/OptionModelPropertyWrapperTests.cs
+++ b/src/Community.VisualStudio.Toolkit.UnitTests/OptionModelPropertyWrapperTests.cs
@@ -1124,7 +1124,7 @@ namespace Community.VisualStudio.Toolkit.UnitTests
 
             if (destinationType == typeof(byte[]))
             {
-                var tmpStr = ToString(customType);
+                string? tmpStr = ToString(customType);
                 return Encoding.UTF8.GetBytes(tmpStr);
             }
 

--- a/test/VSSDK.TestExtension/ToolWindows/ThemeWindow/ThemeWindow.cs
+++ b/test/VSSDK.TestExtension/ToolWindows/ThemeWindow/ThemeWindow.cs
@@ -32,7 +32,7 @@ namespace TestExtension
 
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
-            var manager = (IVsSettingsManager)await VS.Services.GetSettingsManagerAsync();
+            IVsSettingsManager manager = (IVsSettingsManager)await VS.Services.GetSettingsManagerAsync();
             SettingsStore store = new ShellSettingsManager(manager).GetReadOnlySettingsStore(SettingsScope.UserSettings);
 
             if (store.CollectionExists(COLLECTION_NAME))
@@ -41,7 +41,7 @@ namespace TestExtension
                 {
                     // The value is made up of three parts, separated
                     // by a star. The third part is the GUID of the theme.
-                    var parts = store.GetString(COLLECTION_NAME, PROPERTY_NAME).Split('*');
+                    string[] parts = store.GetString(COLLECTION_NAME, PROPERTY_NAME).Split('*');
                     if (parts.Length == 3)
                     {
                         if (Guid.TryParse(parts[2], out Guid value))

--- a/test/VSSDK.TestExtension/ToolWindows/ThemeWindow/ThemeWindowControlViewModel.cs
+++ b/test/VSSDK.TestExtension/ToolWindows/ThemeWindow/ThemeWindowControlViewModel.cs
@@ -77,7 +77,7 @@ namespace TestExtension
             // There doesn't appear to be a way to set the theme programatically, 
             // but we can change the theme by using a pre-defined settings file and importing those settings.
             // The settings files were created by exporting only the "Options/General/Font and Colors" setting.
-            var tempFileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("n") + ".vssettings");
+            string tempFileName = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("n") + ".vssettings");
 
             using (Stream resource = GetType().Assembly.GetManifestResourceStream($"TestExtension.Resources.{theme.ResourceName}"))
             {


### PR DESCRIPTION
All current uses of `var` were updated to use explicit types.