### PR TITLE
Support virtual folder types

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/Solution/PhysicalFolder.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Solution/PhysicalFolder.cs
@@ -11,9 +11,9 @@ namespace Community.VisualStudio.Toolkit
     /// <summary>
     /// Represents a physical folder in the solution hierarchy.
     /// </summary>
-    public class Folder : SolutionItem
+    public class PhysicalFolder : SolutionItem
     {
-        internal Folder(IVsHierarchyItem item, SolutionItemType type) : base(item, type)
+        internal PhysicalFolder(IVsHierarchyItem item, SolutionItemType type) : base(item, type)
         { ThreadHelper.ThrowIfNotOnUIThread(); }
 
         /// <summary>

--- a/src/Community.VisualStudio.Toolkit.Shared/Solution/SolutionItem.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Solution/SolutionItem.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -125,13 +126,14 @@ namespace Community.VisualStudio.Toolkit
             }
 
             SolutionItemType type = GetSolutionItemType(item.HierarchyIdentity);
-            
+
             return type switch
             {
                 SolutionItemType.Solution => new Solution(item, type),
                 SolutionItemType.Project => new Project(item, type),
                 SolutionItemType.PhysicalFile => new File(item, type),
-                SolutionItemType.PhysicalFolder => new Folder(item, type),
+                SolutionItemType.PhysicalFolder => new PhysicalFolder(item, type),
+                SolutionItemType.VirtualFolder => new VirtualFolder(item, type),
                 SolutionItemType.SolutionFolder => new SolutionFolder(item, type),
                 _ => new SolutionItem(item, type)
             };
@@ -166,6 +168,12 @@ namespace Community.VisualStudio.Toolkit
             else if (HierarchyUtilities.IsPhysicalFolder(identity))
             {
                 return SolutionItemType.PhysicalFolder;
+            }
+
+            Guid itemType = HierarchyUtilities.GetItemType(identity);
+            if (itemType == VSConstants.ItemTypeGuid.VirtualFolder_guid)
+            {
+                return SolutionItemType.VirtualFolder;
             }
 
             return SolutionItemType.Unknown;

--- a/src/Community.VisualStudio.Toolkit.Shared/Solution/SolutionItem.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Solution/SolutionItem.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -183,7 +183,7 @@ namespace Community.VisualStudio.Toolkit
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            if (Type == SolutionItemType.SolutionFolder)
+            if (Type == SolutionItemType.Unknown || IsVirtualItem(Type))
             {
                 return null;
             }
@@ -201,6 +201,17 @@ namespace Community.VisualStudio.Toolkit
             }
 
             return fileName;
+        }
+
+        private static bool IsVirtualItem(SolutionItemType type)
+        {
+            return type switch
+            {
+                SolutionItemType.SolutionFolder => true,
+                SolutionItemType.VirtualProject => true,
+                SolutionItemType.VirtualFolder => true,
+                _ => false
+            };
         }
     }
 }

--- a/src/Community.VisualStudio.Toolkit.Shared/Solution/SolutionItemType.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Solution/SolutionItemType.cs
@@ -21,5 +21,7 @@
         SolutionFolder,
         /// <summary>An unknown item.</summary>
         Unknown,
+        /// <summary>A virtual folder.</summary>
+        VirtualFolder,
     }
 }

--- a/src/Community.VisualStudio.Toolkit.Shared/Solution/VirtualFolder.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Solution/VirtualFolder.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.VisualStudio.Shell;
+
+namespace Community.VisualStudio.Toolkit
+{
+    /// <summary>
+    /// Represents a virtual folder in the solution hierarchy.
+    /// </summary>
+    public class VirtualFolder : SolutionItem
+    {
+        internal VirtualFolder(IVsHierarchyItem item, SolutionItemType type) : base(item, type)
+        { ThreadHelper.ThrowIfNotOnUIThread(); }
+
+        /// <summary>
+        /// The project containing this folder, or <see langword="null"/>.
+        /// </summary>
+        public Project? ContainingProject => FindParent(SolutionItemType.Project) as Project;
+    }
+}

--- a/src/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
+++ b/src/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
@@ -28,7 +28,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Debugger\DebuggerEvents.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Selection\SelectionEvents.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Solution\Folder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Solution\PhysicalFolder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Solution\VirtualFolder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Solution\File.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Solution\Project.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Solution\Solution.cs" />


### PR DESCRIPTION
Fixes #143. 

Added a `VirtualFolder` type to cover items in a solution like the `References` node of .NET Framework projects or the `Dependencies` node in SDK projects.

I've renamed `Folder` to `PhysicalFolder` to make it clear that it's a physical folder.

To fix the actual error in #143, the full path of a "virtual" or "unknown" item is not retrieved.