### PR TITLE
Created a class for accessing and manipulating Solution Explorer

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
+++ b/src/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
@@ -67,6 +67,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ToolkitPackage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows\BaseToolWindow.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows\IToolWindowProvider.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows\SolutionExplorerWindow.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows\WindowEvents.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows\WindowFrame.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows\WindowGuids.cs" />

--- a/src/Community.VisualStudio.Toolkit.Shared/Windows/SolutionExplorerWindow.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Windows/SolutionExplorerWindow.cs
@@ -1,0 +1,390 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Design;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Community.VisualStudio.Toolkit
+{
+    /// <summary>
+    /// Provides access to the Solution Explorer tool window.
+    /// </summary>
+    public class SolutionExplorerWindow
+    {
+        internal SolutionExplorerWindow(IVsWindowFrame frame, IVsUIHierarchyWindow window)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            Frame = frame;
+            UIHierarchyWindow = window;
+            SolutionUIHierarchyWindow = (IVsSolutionUIHierarchyWindow)window;
+        }
+
+        /// <summary>
+        /// Gets the Solution Explorer frame.
+        /// </summary>
+        public IVsWindowFrame Frame { get; }
+
+        /// <summary>
+        /// Gets the internal <see cref="IVsUIHierarchyWindow"/> that is used by Solution Explorer.
+        /// </summary>
+        public IVsUIHierarchyWindow UIHierarchyWindow { get; }
+
+        /// <summary>
+        /// Gets the internal <see cref="IVsSolutionUIHierarchyWindow"/> that is used by Solution Explorer.
+        /// </summary>
+        public IVsSolutionUIHierarchyWindow SolutionUIHierarchyWindow { get; }
+
+        /// <summary>
+        /// Determines whether Solution Explorer is currently being filtered by any filter.
+        /// </summary>
+        public bool IsFilterEnabled()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            return SolutionUIHierarchyWindow.IsFilterEnabled();
+        }
+
+        /// <summary>
+        /// Determines whether Solution Explorer is currently being filtered by the specified filter.
+        /// </summary>
+        /// <typeparam name="TFilter">The type of the filter to test for.</typeparam>
+        public bool IsFilterEnabled<TFilter>() where TFilter : HierarchyTreeFilterProvider
+        {
+            GetFilterIdentifier<TFilter>(out Guid filterGroup, out uint filterId);
+            return IsFilterEnabled(filterGroup, filterId);
+        }
+
+        /// <summary>
+        /// Determines whether Solution Explorer is currently being filtered by any filter.
+        /// </summary>
+        public bool IsFilterEnabled(Guid filterGroup, uint filterId)
+        {
+            if (IsFilterEnabled())
+            {
+                CommandID? current = GetCurrentFilter();
+                return (current != null) && (current.Guid == filterGroup) && (current.ID == filterId);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Disables filtering in Solution Explorer.
+        /// </summary>
+        public void DisableFilter()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            SolutionUIHierarchyWindow.DisableFilter();
+        }
+
+        /// <summary>
+        /// Enables the specified Solution Explorer filter.
+        /// </summary>
+        /// <typeparam name="TFilter">The type of the filter to enable.</typeparam>
+        public void EnableFilter<TFilter>() where TFilter : HierarchyTreeFilterProvider
+        {
+            GetFilterIdentifier<TFilter>(out Guid filterGroup, out uint filterId);
+            EnableFilter(filterGroup, filterId);
+        }
+
+        /// <summary>
+        /// Enables the specified Solution Explorer filter.
+        /// </summary>
+        /// <param name="filterGroup">The GUID of the filter's group.</param>
+        /// <param name="filterId">The ID of the filter.</param>
+        public void EnableFilter(Guid filterGroup, uint filterId)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            SolutionUIHierarchyWindow.EnableFilter(ref filterGroup, filterId);
+        }
+
+        /// <summary>
+        /// Gets the current filter that is applied to Solution Explorer.
+        /// </summary>
+        public CommandID? GetCurrentFilter()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            SolutionUIHierarchyWindow.GetCurrentFilter(out Guid filterGroup, out uint filterId);
+            if (filterGroup != default)
+            {
+                return new CommandID(filterGroup, (int)filterId);
+            }
+            return null;
+        }
+
+        private void GetFilterIdentifier<TFilter>(out Guid filterGroup, out uint filterId) where TFilter : HierarchyTreeFilterProvider
+        {
+            SolutionTreeFilterProviderAttribute? attribute = typeof(TFilter).GetCustomAttribute<SolutionTreeFilterProviderAttribute>();
+            if (attribute is null)
+            {
+                throw new InvalidOperationException($"The type '{typeof(TFilter).FullName}' is missing the {nameof(SolutionTreeFilterProviderAttribute)} attribute.");
+            }
+            filterGroup = Guid.Parse(attribute.FilterCommandGroup);
+            filterId = attribute.FilterCommandID;
+        }
+
+        /// <summary>
+        /// Gets the selected items in Solution Explorer.
+        /// </summary>
+        public async Task<IEnumerable<SolutionItem>> GetSelectionAsync()
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            List<IVsHierarchyItem> hierarchies = new();
+            IntPtr hierPtr = IntPtr.Zero;
+            IntPtr containerPtr = IntPtr.Zero;
+
+            try
+            {
+                // This is similar to `IVsMonitorSelection.GetCurrentSelection()`, but when
+                // there are multiple items selected, the `itemId` parameter will _not_ be
+                // set to `VSITEMID_SELECTION`. Apart from that, the results are identical,
+                // so we can use the same method to convert the result into IVsHierarhcy objects.
+                UIHierarchyWindow.GetCurrentSelection(out hierPtr, out uint itemId, out IVsMultiItemSelect multiSelect);
+
+                if (multiSelect is not null)
+                {
+                    itemId = VSConstants.VSITEMID_SELECTION;
+                }
+
+                await Solutions.AddHierarchiesFromSelectionAsync(hierPtr, itemId, multiSelect, hierarchies);
+            }
+            catch (Exception ex)
+            {
+                await ex.LogAsync();
+            }
+            finally
+            {
+                if (hierPtr != IntPtr.Zero)
+                {
+                    Marshal.Release(hierPtr);
+                }
+
+                if (containerPtr != IntPtr.Zero)
+                {
+                    Marshal.Release(containerPtr);
+                }
+            }
+
+            List<SolutionItem> solutionItems = new();
+
+            foreach (IVsHierarchyItem hierarchy in hierarchies)
+            {
+                SolutionItem? item = await SolutionItem.FromHierarchyAsync(hierarchy.HierarchyIdentity.Hierarchy, hierarchy.HierarchyIdentity.ItemID);
+                if (item != null)
+                {
+                    solutionItems.Add(item);
+                }
+            }
+
+            return solutionItems;
+        }
+
+        /// <summary>
+        /// Sets the selected item in the Solution Explorer window.
+        /// </summary>
+        /// <param name="item">The item to select.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="item"/> is <see langword="null"/>.</exception>
+        public void SetSelection(SolutionItem item)
+        {
+            if (item is null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+
+            SetSelection(new[] { item });
+        }
+
+        /// <summary>
+        /// Sets the selected items in the Solution Explorer window.
+        /// </summary>
+        /// <param name="items">The items to select.</param>
+        public void SetSelection(IEnumerable<SolutionItem> items)
+        {
+            if (items is null)
+            {
+                throw new ArgumentNullException(nameof(items));
+            }
+
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            bool addToSelection = false;
+
+            foreach (SolutionItem item in items)
+            {
+                item.GetItemInfo(out IVsHierarchy hierarchy, out uint itemID, out IVsHierarchyItem _);
+                if (hierarchy is IVsUIHierarchy uiHierarchy)
+                {
+                    if (!addToSelection)
+                    {
+                        // Try to select the item. This will remove the selection from all other items.
+                        UIHierarchyWindow.ExpandItem(uiHierarchy, itemID, EXPANDFLAGS.EXPF_SelectItem);
+
+                        // Check if the item was actually selected. The item may not be visible
+                        // or even exist, and `ExpandItem` doesn't fail in that scenario, so the
+                        // only way to check if the item was selected is to get its current state.
+                        if (ErrorHandler.Succeeded(UIHierarchyWindow.GetItemState(uiHierarchy, itemID, (uint)__VSHIERARCHYITEMSTATE.HIS_Selected, out uint state)))
+                        {
+                            if (state == (uint)__VSHIERARCHYITEMSTATE.HIS_Selected)
+                            {
+                                // The item has been selected, which means that for the
+                                // next item that we need to select, we need to _add_
+                                // to the selection instead of replace the selection.
+                                addToSelection = true;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        UIHierarchyWindow.ExpandItem(uiHierarchy, itemID, EXPANDFLAGS.EXPF_AddSelectItem);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Begins editing of the specified item.
+        /// </summary>
+        /// <param name="item">The item to being editing the label of.</param>
+        public void EditLabel(SolutionItem item)
+        {
+            if (item is null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            item.GetItemInfo(out IVsHierarchy hierarchy, out uint itemID, out IVsHierarchyItem _);
+            if (hierarchy is IVsUIHierarchy uiHierarchy)
+            {
+                UIHierarchyWindow.ExpandItem(uiHierarchy, itemID, EXPANDFLAGS.EXPF_EditItemLabel);
+            }
+        }
+
+        /// <summary>
+        /// Expands the specified item.
+        /// </summary>
+        /// <param name="item">The item to expand.</param>
+        /// <param name="mode">Specifies how the item will be expanded.</param>
+        public void Expand(SolutionItem item, SolutionItemExpansionMode mode = SolutionItemExpansionMode.Single)
+        {
+            if (item is null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+
+            Expand(new[] { item }, mode);
+        }
+
+        /// <summary>
+        /// Expands the specified items.
+        /// </summary>
+        /// <param name="items">The items to expand.</param>
+        /// <param name="mode">Specifies how the items will be expanded.</param>
+        public void Expand(IEnumerable<SolutionItem> items, SolutionItemExpansionMode mode = SolutionItemExpansionMode.Single)
+        {
+            if (items is null)
+            {
+                throw new ArgumentNullException(nameof(items));
+            }
+
+            // Although the `EXPANDFLAGS` has the `[Flags]` attribute, the values 
+            // cannot actually be combined because the values are sequential.
+            // We need to make multiple calls for each mode that is set.
+            if ((mode & SolutionItemExpansionMode.Ancestors) == SolutionItemExpansionMode.Ancestors)
+            {
+                Expand(items, EXPANDFLAGS.EXPF_ExpandParentsToShowItem);
+            }
+
+            // Expanding recursively will also expand the given items, so if we
+            // expand recurisvely, then we don't need to check for the `Single` mode.
+            if ((mode & SolutionItemExpansionMode.Recursive) == SolutionItemExpansionMode.Recursive)
+            {
+                Expand(items, EXPANDFLAGS.EXPF_ExpandFolderRecursively);
+            }
+            else if ((mode & SolutionItemExpansionMode.Single) == SolutionItemExpansionMode.Single)
+            {
+                Expand(items, EXPANDFLAGS.EXPF_ExpandFolder);
+            }
+        }
+
+        private void Expand(IEnumerable<SolutionItem> items, EXPANDFLAGS flag)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            foreach (SolutionItem item in items)
+            {
+                item.GetItemInfo(out IVsHierarchy hierarchy, out uint itemID, out IVsHierarchyItem _);
+                if (hierarchy is IVsUIHierarchy uiHierarchy)
+                {
+                    UIHierarchyWindow.ExpandItem(uiHierarchy, itemID, flag);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Collapses the specified item.
+        /// </summary>
+        /// <param name="item">The item to collapse.</param>
+        public void Collapse(SolutionItem item)
+        {
+            if (item is null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+
+            Collapse(new[] { item });
+        }
+
+        /// <summary>
+        /// Collapses the specified items.
+        /// </summary>
+        /// <param name="items">The items to collapse.</param>
+        public void Collapse(IEnumerable<SolutionItem> items)
+        {
+            if (items is null)
+            {
+                throw new ArgumentNullException(nameof(items));
+            }
+
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            foreach (SolutionItem item in items)
+            {
+                item.GetItemInfo(out IVsHierarchy hierarchy, out uint itemID, out IVsHierarchyItem _);
+                if (hierarchy is IVsUIHierarchy uiHierarchy)
+                {
+                    UIHierarchyWindow.ExpandItem(uiHierarchy, itemID, EXPANDFLAGS.EXPF_CollapseFolder);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Defines how a Solution Explorer item should be expanded.
+    /// </summary>
+    [Flags]
+    public enum SolutionItemExpansionMode
+    {
+        /// <summary>
+        /// The item and its ancestors and descendants will not be expanded.
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// Only the specified item will be expanded. Ancestors and descendants will not be expanded.
+        /// </summary>
+        Single = 1,
+        /// <summary>
+        /// The specified item and all descendants will be expanded. Ancestors will not be expanded.
+        /// </summary>
+        Recursive = 2,
+        /// <summary>
+        /// The ancestors of the item will be expanded. The item itself and its children will not be expanded.
+        /// </summary>
+        Ancestors = 4
+    }
+}

--- a/src/Community.VisualStudio.Toolkit.Shared/Windows/Windows.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Windows/Windows.cs
@@ -196,6 +196,7 @@ namespace Community.VisualStudio.Toolkit
             }
             return frames;
         }
+
         /// <summary>
         /// Obtains all window frames for ToolWindows and DocumentWindows visible in the IDE.
         /// </summary>
@@ -208,5 +209,26 @@ namespace Community.VisualStudio.Toolkit
             return allwindows;
         }
 
+        /// <summary>
+        /// Gets the Solution Explorer window.
+        /// </summary>
+        /// <returns>The Solution Explorer window.</returns>
+        public async Task<SolutionExplorerWindow?> GetSolutionExplorerWindowAsync()
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            IVsUIShell shell = await VS.Services.GetUIShellAsync();
+            Guid slot = Guid.Parse(WindowGuids.SolutionExplorer);
+
+            ErrorHandler.ThrowOnFailure(shell.FindToolWindow(0, ref slot, out IVsWindowFrame frame));
+            ErrorHandler.ThrowOnFailure(frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out object? docView));
+
+            if (docView is not null)
+            {
+                return new SolutionExplorerWindow(frame, (IVsUIHierarchyWindow)docView);
+            }
+
+            return null;
+        }
     }
 }

--- a/test/VSSDK.TestExtension/Commands/CollapseSelectedItemsCommand.cs
+++ b/test/VSSDK.TestExtension/Commands/CollapseSelectedItemsCommand.cs
@@ -1,0 +1,21 @@
+﻿using Community.VisualStudio.Toolkit;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+namespace TestExtension
+{
+    [Command(PackageIds.CollapseSelectedItems)]
+    internal sealed class CollapseSelectedItemsCommand : BaseCommand<CollapseSelectedItemsCommand>
+    {
+        protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            SolutionExplorerWindow solutionExplorer = await VS.Windows.GetSolutionExplorerWindowAsync();
+            if (solutionExplorer != null)
+            {
+                solutionExplorer.Collapse(await solutionExplorer.GetSelectionAsync());
+            }
+        }
+    }
+}

--- a/test/VSSDK.TestExtension/Commands/EditSelectedItemLabelCommand.cs
+++ b/test/VSSDK.TestExtension/Commands/EditSelectedItemLabelCommand.cs
@@ -1,0 +1,26 @@
+﻿using System.Linq;
+using Community.VisualStudio.Toolkit;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+namespace TestExtension
+{
+    [Command(PackageIds.EditSelectedItemLabel)]
+    internal sealed class EditSelectedItemLabelCommand : BaseCommand<EditSelectedItemLabelCommand>
+    {
+        protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            SolutionExplorerWindow solutionExplorer = await VS.Windows.GetSolutionExplorerWindowAsync();
+            if (solutionExplorer != null)
+            {
+                SolutionItem item = (await solutionExplorer.GetSelectionAsync()).FirstOrDefault();
+                if (item != null)
+                {
+                    solutionExplorer.EditLabel(item);
+                }
+            }
+        }
+    }
+}

--- a/test/VSSDK.TestExtension/Commands/ExpandSelectedItemsCommand.cs
+++ b/test/VSSDK.TestExtension/Commands/ExpandSelectedItemsCommand.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using System.Windows.Input;
+using Community.VisualStudio.Toolkit;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+namespace TestExtension
+{
+    [Command(PackageIds.ExpandSelectedItems)]
+    internal sealed class ExpandSelectedItemsCommand : BaseCommand<ExpandSelectedItemsCommand>
+    {
+        protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            SolutionExplorerWindow solutionExplorer = await VS.Windows.GetSolutionExplorerWindowAsync();
+            if (solutionExplorer != null)
+            {
+                IEnumerable<SolutionItem> items = await solutionExplorer.GetSelectionAsync();
+                SolutionItemExpansionMode mode = SolutionItemExpansionMode.None;
+
+                ModifierKeys modifiers = Keyboard.Modifiers;
+                if (modifiers == ModifierKeys.None)
+                {
+                    mode = SolutionItemExpansionMode.Single;
+                }
+                else
+                {
+                    if ((modifiers & ModifierKeys.Control) == ModifierKeys.Control)
+                    {
+                        mode |= SolutionItemExpansionMode.Recursive;
+                    }
+
+                    if ((modifiers & ModifierKeys.Shift) == ModifierKeys.Shift)
+                    {
+                        // To expand to the selected items, theose items and their ancestors
+                        // all need to be collapsed, so collapse them first, then pause for a
+                        // moment so that you can see that we start from a collapsed state.
+                        foreach (SolutionItem item in items)
+                        {
+                            CollapseRecursively(solutionExplorer, item);
+                        }
+                        await Task.Delay(2000);
+                        mode |= SolutionItemExpansionMode.Ancestors;
+                    }
+                }
+
+                solutionExplorer.Expand(items, mode);
+            }
+        }
+
+        private void CollapseRecursively(SolutionExplorerWindow solutionExplorer, SolutionItem item)
+        {
+            while (item != null)
+            {
+                solutionExplorer.Collapse(item);
+                item = item.Parent;
+            }
+        }
+    }
+}

--- a/test/VSSDK.TestExtension/Commands/SelectCurrentProjectCommand.cs
+++ b/test/VSSDK.TestExtension/Commands/SelectCurrentProjectCommand.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using Community.VisualStudio.Toolkit;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+namespace TestExtension
+{
+    [Command(PackageIds.SelectCurrentProject)]
+    internal sealed class SelectCurrentProjectCommand : BaseCommand<SelectCurrentProjectCommand>
+    {
+        protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            SolutionExplorerWindow solutionExplorer = await VS.Windows.GetSolutionExplorerWindowAsync();
+            if (solutionExplorer != null)
+            {
+                List<SolutionItem> projects = new List<SolutionItem>();
+                foreach (SolutionItem item in await solutionExplorer.GetSelectionAsync())
+                {
+                    SolutionItem project = item.FindParent(SolutionItemType.Project);
+                    if (project != null)
+                    {
+                        projects.Add(project);
+                    }
+                }
+
+                if (projects.Count > 0)
+                {
+                    solutionExplorer.SetSelection(projects);
+                }
+            }
+        }
+    }
+}

--- a/test/VSSDK.TestExtension/Commands/ToggleVsixManifestFilterCommand.cs
+++ b/test/VSSDK.TestExtension/Commands/ToggleVsixManifestFilterCommand.cs
@@ -1,0 +1,28 @@
+﻿using Community.VisualStudio.Toolkit;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+namespace TestExtension
+{
+    [Command(PackageIds.ToggleVsixManifestFilter)]
+    internal sealed class ToggleVsixManifestFilterCommand : BaseCommand<ToggleVsixManifestFilterCommand>
+    {
+        protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            SolutionExplorerWindow solutionExplorer = await VS.Windows.GetSolutionExplorerWindowAsync();
+            if (solutionExplorer != null)
+            {
+                if (solutionExplorer.IsFilterEnabled<VsixManifestFilterProvider>())
+                {
+                    solutionExplorer.DisableFilter();
+                }
+                else
+                {
+                    solutionExplorer.EnableFilter<VsixManifestFilterProvider>();
+                }
+            }
+        }
+    }
+}

--- a/test/VSSDK.TestExtension/SolutionExplorer/VsixManifestFilterProvider.cs
+++ b/test/VSSDK.TestExtension/SolutionExplorer/VsixManifestFilterProvider.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.Internal.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Shell;
+
+namespace TestExtension
+{
+    [SolutionTreeFilterProvider(PackageGuids.TestExtensionString, PackageIds.VsixManifestSolutionExplorerFilter)]
+    public class VsixManifestFilterProvider : HierarchyTreeFilterProvider
+    {
+        private readonly IVsHierarchyItemCollectionProvider _hierarchyCollectionProvider;
+
+        [ImportingConstructor]
+        public VsixManifestFilterProvider(IVsHierarchyItemCollectionProvider hierarchyCollectionProvider)
+        {
+            _hierarchyCollectionProvider = hierarchyCollectionProvider;
+        }
+
+        protected override HierarchyTreeFilter CreateFilter()
+        {
+            return new Filter(_hierarchyCollectionProvider);
+        }
+
+        private sealed class Filter : HierarchyTreeFilter
+        {
+            private static readonly Regex _pattern = new Regex(@"\.vsixmanifest$", RegexOptions.IgnoreCase);
+
+            private readonly IVsHierarchyItemCollectionProvider _hierarchyCollectionProvider;
+
+            public Filter(IVsHierarchyItemCollectionProvider hierarchyCollectionProvider)
+            {
+                _hierarchyCollectionProvider = hierarchyCollectionProvider;
+            }
+
+            protected override async Task<IReadOnlyObservableSet> GetIncludedItemsAsync(IEnumerable<IVsHierarchyItem> rootItems)
+            {
+                IVsHierarchyItem root = HierarchyUtilities.FindCommonAncestor(rootItems);
+                IReadOnlyObservableSet<IVsHierarchyItem> sourceItems;
+
+                sourceItems = await _hierarchyCollectionProvider.GetDescendantsAsync(root.HierarchyIdentity.NestedHierarchy, CancellationToken);
+
+                return await _hierarchyCollectionProvider.GetFilteredHierarchyItemsAsync(sourceItems, MeetsFilter, CancellationToken);
+            }
+
+            private static bool MeetsFilter(IVsHierarchyItem item)
+            {
+                return (item != null) && _pattern.IsMatch(item.Text);
+            }
+        }
+    }
+}

--- a/test/VSSDK.TestExtension/VSCommandTable.cs
+++ b/test/VSSDK.TestExtension/VSCommandTable.cs
@@ -21,11 +21,19 @@ namespace TestExtension
     internal sealed partial class PackageIds
     {
         public const int TestExtensionMainMenu = 0x1000;
+        public const int TestExtensionSolutionExplorerMenu = 0x1001;
         public const int TestExtensionMainMenuGroup1 = 0x1100;
+        public const int TestExtensionSolutionExplorerGroup = 0x1101;
         public const int RunnerWindow = 0x0100;
         public const int ThemeWindow = 0x0101;
         public const int MultiInstanceWindow = 0x0102;
         public const int BuildActiveProjectAsync = 0x0103;
         public const int BuildSolutionAsync = 0x0104;
+        public const int VsixManifestSolutionExplorerFilter = 0x0105;
+        public const int ToggleVsixManifestFilter = 0x0106;
+        public const int SelectCurrentProject = 0x0107;
+        public const int EditSelectedItemLabel = 0x0108;
+        public const int ExpandSelectedItems = 0x0109;
+        public const int CollapseSelectedItems = 0x0110;
     }
 }

--- a/test/VSSDK.TestExtension/VSCommandTable.vsct
+++ b/test/VSSDK.TestExtension/VSCommandTable.vsct
@@ -17,11 +17,22 @@
           <ButtonText>VSSDK Test Extension</ButtonText>
         </Strings>
       </Menu>
+
+      <Menu guid="TestExtension" id="TestExtensionSolutionExplorerMenu" priority="0x0200" type="Menu">
+        <Parent guid="TestExtension" id="TestExtensionMainMenuGroup1" />
+        <Strings>
+          <ButtonText>Solution Explorer</ButtonText>
+        </Strings>
+      </Menu>
     </Menus>
     
     <Groups>
       <Group guid="TestExtension" id="TestExtensionMainMenuGroup1" priority="0x1100">
         <Parent guid="TestExtension" id="TestExtensionMainMenu" />
+      </Group>
+      
+      <Group guid="TestExtension" id="TestExtensionSolutionExplorerGroup" priority="0x1101">
+        <Parent guid="TestExtension" id="TestExtensionSolutionExplorerMenu" />
       </Group>
     </Groups>
     
@@ -53,6 +64,15 @@
         </Strings>
       </Button>
 
+      <Button guid="TestExtension" id="VsixManifestSolutionExplorerFilter" priority="0x0400" type="Button">
+        <Parent guid="guidSHLMainMenu" id="IDG_VS_TOOLBAR_PROJWIN_FILTERS" />
+        <Icon guid="ImageCatalogGuid" id="VisualStudioSettingsFile" />
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <Strings>
+          <ButtonText>VSIX Manifest Filter</ButtonText>
+        </Strings>
+      </Button>
+
       <Button guid="TestExtension" id="BuildActiveProjectAsync" priority="0x0100" type="Button">
         <Parent guid="TestExtension" id="TestExtensionMainMenuGroup1"/>
         <Icon guid="ImageCatalogGuid" id="BuildSelection" />
@@ -70,19 +90,64 @@
           <ButtonText>Build Solution Async</ButtonText>
         </Strings>
       </Button>
+
+      <Button guid="TestExtension" id="ToggleVsixManifestFilter" priority="0x0100" type="Button">
+        <Parent guid="TestExtension" id="TestExtensionSolutionExplorerGroup"/>
+        <Icon guid="ImageCatalogGuid" id="VisualStudioSettingsFile" />
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <Strings>
+          <ButtonText>Toggle VSIX Manifest Filter</ButtonText>
+        </Strings>
+      </Button>
+
+      <Button guid="TestExtension" id="SelectCurrentProject" priority="0x0101" type="Button">
+        <Parent guid="TestExtension" id="TestExtensionSolutionExplorerGroup"/>
+        <Strings>
+          <ButtonText>Select Current Project</ButtonText>
+        </Strings>
+      </Button>
+
+      <Button guid="TestExtension" id="EditSelectedItemLabel" priority="0x0102" type="Button">
+        <Parent guid="TestExtension" id="TestExtensionSolutionExplorerGroup"/>
+        <Strings>
+          <ButtonText>Edit Selected Item Label</ButtonText>
+        </Strings>
+      </Button>
+
+      <Button guid="TestExtension" id="ExpandSelectedItems" priority="0x0103" type="Button">
+        <Parent guid="TestExtension" id="TestExtensionSolutionExplorerGroup"/>
+        <Strings>
+          <ButtonText>Expand Selected Items</ButtonText>
+        </Strings>
+      </Button>
+
+      <Button guid="TestExtension" id="CollapseSelectedItems" priority="0x0104" type="Button">
+        <Parent guid="TestExtension" id="TestExtensionSolutionExplorerGroup"/>
+        <Strings>
+          <ButtonText>Collapse Selected Items</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
   </Commands>
 
   <Symbols>
     <GuidSymbol name="TestExtension" value="{05271709-8845-42fb-9d10-621cc8cffc5d}">
       <IDSymbol name="TestExtensionMainMenu" value="0x1000" />
+      <IDSymbol name="TestExtensionSolutionExplorerMenu" value="0x1001" />
       <IDSymbol name="TestExtensionMainMenuGroup1" value="0x1100" />
-      
+      <IDSymbol name="TestExtensionSolutionExplorerGroup" value="0x1101" />
+
       <IDSymbol name="RunnerWindow" value="0x0100" />
       <IDSymbol name="ThemeWindow" value="0x0101" />
       <IDSymbol name="MultiInstanceWindow" value="0x0102" />
       <IDSymbol name="BuildActiveProjectAsync" value="0x0103" />
       <IDSymbol name="BuildSolutionAsync" value="0x0104" />
+      <IDSymbol name="VsixManifestSolutionExplorerFilter" value="0x0105" />
+      <IDSymbol name="ToggleVsixManifestFilter" value="0x0106" />
+      <IDSymbol name="SelectCurrentProject" value="0x0107" />
+      <IDSymbol name="EditSelectedItemLabel" value="0x0108" />
+      <IDSymbol name="ExpandSelectedItems" value="0x0109" />
+      <IDSymbol name="CollapseSelectedItems" value="0x0110" />
     </GuidSymbol>
   </Symbols>
 </CommandTable>

--- a/test/VSSDK.TestExtension/VSSDK.TestExtension.csproj
+++ b/test/VSSDK.TestExtension/VSSDK.TestExtension.csproj
@@ -47,12 +47,18 @@
   <ItemGroup>
     <Compile Include="Commands\BuildActiveProjectAsyncCommand.cs" />
     <Compile Include="Commands\BuildSolutionAsyncCommand.cs" />
+    <Compile Include="Commands\CollapseSelectedItemsCommand.cs" />
+    <Compile Include="Commands\ExpandSelectedItemsCommand.cs" />
     <Compile Include="Commands\MultiInstanceWindowCommand.cs" />
+    <Compile Include="Commands\EditSelectedItemLabelCommand.cs" />
+    <Compile Include="Commands\SelectCurrentProjectCommand.cs" />
+    <Compile Include="Commands\ToggleVsixManifestFilterCommand.cs" />
     <Compile Include="Commands\RunnerWindowCommand.cs" />
     <Compile Include="Commands\ThemeWindowCommand.cs" />
     <Compile Include="MEF\TextViewCreationListener.cs" />
     <Compile Include="Options\General.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SolutionExplorer\VsixManifestFilterProvider.cs" />
     <Compile Include="ToolWindows\MultiInstanceWindow.cs" />
     <Compile Include="ToolWindows\MultiInstanceWindowControl.xaml.cs">
       <DependentUpon>MultiInstanceWindowControl.xaml</DependentUpon>


### PR DESCRIPTION
Fixes #98.

The `SolutionExplorerWindow` class provides access to the Solution Explorer tool window, and lets you do things like setting the selection, expanding and collapsing items and applying filters.

The window can be retrieved via the `VS.Windows.GetSolutionExplorerWindowAsync()` method.

As well as the methods to manipulate the Solution Explorer window, I've also exposed the underlying `IVsUIHierarchyWindow` and `IVsSolutionUIHierarchyWindow` objects (they're actually the same object), as well as the `IVsWindowFrame` that contains Solution Explorer, in case you need to do stuff that the `SolutionExplorerWindow` doesn't provide (in my use case I needed access to the `IVsWindowFrame` so that I could activate the window).

----
To assist with testing, and to provide a demonstration, I've created one Solution Explorer filter and five commands in the test extension. These commands all appear in the _Extensions->VSSDK Test Extension->Solution Explorer_ menu.
![image](https://user-images.githubusercontent.com/10321525/132833842-1d8a1a05-1d1e-4729-9d05-f55e146c3a87.png)

The Solution Explorer filter also appears in the Solution Explorer toolbar.
![image](https://user-images.githubusercontent.com/10321525/132833948-cbb378da-7864-469f-8065-36ecfa42eb09.png)

* _Toggle VSIX Manifest Filter_ will enable and disable the filter. The filter will hide everything except for `*.vsixmanifest` files.
* _Select Current Project_ will get the current selection from Solution Explorer, then select the project that contains that selected file. This also works when multiple files are selected.
* _Edit Selected Item Label_ will have the same effect as pressing F2 in Solution Explorer.
* _Expand Selected Items_ will expand the selected items in Solution Explorer. There are multiple ways to expand an item, and they can be tested by holding down different keys when clicking this menu item.
    * Not pressing any keys will just expand the selected items (corresponds to `EXPANDFLAGS.EXPF_ExpandFolder`).
    * Holding down <kbd>Ctrl</kbd>will expand the selected items and all of their descendants (corresponds to `EXPANDFLAGS.EXPF_ExpandFolderRecursively`).
    * Holding down <kbd>Shift</kbd> will expand the ancestors of the selected items (corresponds to `EXPANDFLAGS.EXPF_ExpandParentsToShowItem`). To be able to demonstrate this, the selected items are first collapsed all the way up to the solution, and then they are expanded after a short pause.
    * Holding down both <kbd>Ctrl</kbd> and <kbd>Shift</kbd> will expand the ancestors and the descendants of the selected items.
* _Collapse Selected Items_ will collapse the selected items in Solution Explorer.

