### PR TITLE
Fixed compiler warnings

### DIFF
--- a/src/Community.VisualStudio.Toolkit.Shared/Projects/ProjectItemsEvents.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Projects/ProjectItemsEvents.cs
@@ -210,6 +210,11 @@ namespace Community.VisualStudio.Toolkit
     /// </summary>
     public class ProjectItemRenameDetails
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProjectItemRenameDetails"/> class.
+        /// </summary>
+        /// <param name="solutionItem">The solution item that was renamed.</param>
+        /// <param name="oldName">The old name of the solution item.</param>
         public ProjectItemRenameDetails(SolutionItem? solutionItem, string? oldName)
         {
             SolutionItem = solutionItem;
@@ -249,6 +254,11 @@ namespace Community.VisualStudio.Toolkit
     /// </summary>
     public class ProjectItemRemoveDetails
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProjectItemRemoveDetails"/> class.
+        /// </summary>
+        /// <param name="project">The project that the item was removed from.</param>
+        /// <param name="itemName">The name of the item that was removed.</param>
         public ProjectItemRemoveDetails(Project? project, string? itemName)
         {
             Project = project;

--- a/src/Community.VisualStudio.Toolkit.Shared/Projects/ProjectItemsEvents.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Projects/ProjectItemsEvents.cs
@@ -47,24 +47,28 @@ namespace Community.VisualStudio.Toolkit
 
         int IVsTrackProjectDocumentsEvents2.OnAfterAddFilesEx(int cProjects, int cFiles, IVsProject[] rgpProjects, int[] rgFirstIndices, string[] rgpszMkDocuments, VSADDFILEFLAGS[] rgFlags)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             HandleAddItems(cProjects, cFiles, rgpProjects, rgFirstIndices, rgpszMkDocuments);
             return VSConstants.S_OK;
         }
 
         int IVsTrackProjectDocumentsEvents2.OnAfterAddDirectoriesEx(int cProjects, int cDirectories, IVsProject[] rgpProjects, int[] rgFirstIndices, string[] rgpszMkDocuments, VSADDDIRECTORYFLAGS[] rgFlags)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             HandleAddItems(cProjects, cDirectories, rgpProjects, rgFirstIndices, rgpszMkDocuments);
             return VSConstants.S_OK;
         }
 
         int IVsTrackProjectDocumentsEvents2.OnAfterRemoveFiles(int cProjects, int cFiles, IVsProject[] rgpProjects, int[] rgFirstIndices, string[] rgpszMkDocuments, VSREMOVEFILEFLAGS[] rgFlags)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             HandleRemoveItems(cProjects, cFiles, rgpProjects, rgFirstIndices, rgpszMkDocuments);
             return VSConstants.S_OK;
         }
 
         int IVsTrackProjectDocumentsEvents2.OnAfterRemoveDirectories(int cProjects, int cDirectories, IVsProject[] rgpProjects, int[] rgFirstIndices, string[] rgpszMkDocuments, VSREMOVEDIRECTORYFLAGS[] rgFlags)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             HandleRemoveItems(cProjects, cDirectories, rgpProjects, rgFirstIndices, rgpszMkDocuments);
             return VSConstants.S_OK;
         }
@@ -73,6 +77,7 @@ namespace Community.VisualStudio.Toolkit
 
         int IVsTrackProjectDocumentsEvents2.OnAfterRenameFiles(int cProjects, int cFiles, IVsProject[] rgpProjects, int[] rgFirstIndices, string[] rgszMkOldNames, string[] rgszMkNewNames, VSRENAMEFILEFLAGS[] rgFlags)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             HandleRenamedItems(cProjects, cFiles, rgpProjects, rgFirstIndices, rgszMkOldNames, rgszMkNewNames);
             return VSConstants.S_OK;
         }
@@ -81,6 +86,7 @@ namespace Community.VisualStudio.Toolkit
 
         int IVsTrackProjectDocumentsEvents2.OnAfterRenameDirectories(int cProjects, int cDirs, IVsProject[] rgpProjects, int[] rgFirstIndices, string[] rgszMkOldNames, string[] rgszMkNewNames, VSRENAMEDIRECTORYFLAGS[] rgFlags)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             HandleRenamedItems(cProjects, cDirs, rgpProjects, rgFirstIndices, rgszMkOldNames, rgszMkNewNames);
             return VSConstants.S_OK;
         }

--- a/src/Community.VisualStudio.Toolkit.Shared/Windows/SolutionExplorerWindow.cs
+++ b/src/Community.VisualStudio.Toolkit.Shared/Windows/SolutionExplorerWindow.cs
@@ -53,6 +53,7 @@ namespace Community.VisualStudio.Toolkit
         /// <typeparam name="TFilter">The type of the filter to test for.</typeparam>
         public bool IsFilterEnabled<TFilter>() where TFilter : HierarchyTreeFilterProvider
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             GetFilterIdentifier<TFilter>(out Guid filterGroup, out uint filterId);
             return IsFilterEnabled(filterGroup, filterId);
         }
@@ -62,6 +63,7 @@ namespace Community.VisualStudio.Toolkit
         /// </summary>
         public bool IsFilterEnabled(Guid filterGroup, uint filterId)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             if (IsFilterEnabled())
             {
                 CommandID? current = GetCurrentFilter();
@@ -86,6 +88,7 @@ namespace Community.VisualStudio.Toolkit
         /// <typeparam name="TFilter">The type of the filter to enable.</typeparam>
         public void EnableFilter<TFilter>() where TFilter : HierarchyTreeFilterProvider
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             GetFilterIdentifier<TFilter>(out Guid filterGroup, out uint filterId);
             EnableFilter(filterGroup, filterId);
         }
@@ -195,6 +198,7 @@ namespace Community.VisualStudio.Toolkit
                 throw new ArgumentNullException(nameof(item));
             }
 
+            ThreadHelper.ThrowIfNotOnUIThread();
             SetSelection(new[] { item });
         }
 
@@ -277,6 +281,7 @@ namespace Community.VisualStudio.Toolkit
                 throw new ArgumentNullException(nameof(item));
             }
 
+            ThreadHelper.ThrowIfNotOnUIThread();
             Expand(new[] { item }, mode);
         }
 
@@ -291,6 +296,8 @@ namespace Community.VisualStudio.Toolkit
             {
                 throw new ArgumentNullException(nameof(items));
             }
+
+            ThreadHelper.ThrowIfNotOnUIThread();
 
             // Although the `EXPANDFLAGS` has the `[Flags]` attribute, the values 
             // cannot actually be combined because the values are sequential.
@@ -337,6 +344,7 @@ namespace Community.VisualStudio.Toolkit
                 throw new ArgumentNullException(nameof(item));
             }
 
+            ThreadHelper.ThrowIfNotOnUIThread();
             Collapse(new[] { item });
         }
 


### PR DESCRIPTION
There were a few compiler warnings showing up.

* Some missing XML documentation comments.
* Some missing calls to `ThreadHelper.ThrowIfNotOnUIThread()` that the analyzers were only detecting in the `C.VS.T.14.0` project.