### PR TITLE
Hide tool window

### DIFF
--- a/test/VSSDK.TestExtension/ToolWindows/RunnerWindowControl.xaml
+++ b/test/VSSDK.TestExtension/ToolWindows/RunnerWindowControl.xaml
@@ -3,10 +3,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
-             xmlns:theming="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
-             xmlns:util="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Utilities"
-             xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
              xmlns:toolkit="clr-namespace:Community.VisualStudio.Toolkit;assembly=Community.VisualStudio.Toolkit"
              mc:Ignorable="d"
              toolkit:Themes.UseVsTheme="True"
@@ -15,7 +11,8 @@
     <Grid>
         <StackPanel Orientation="Vertical">
             <Label Name="lblHeadline" Margin="10" HorizontalAlignment="Center">Runner Window</Label>
-            <Button Content="Click me!" Click="button1_Click" Width="120" Height="80" Name="button1"/>
+            <Button Content="Show a message" Click="btnShowMessage_Click" Width="120" Height="80" Name="btnShowMessage"/>
+            <Button Content="Hide me" Click="btnHide_Click" Width="120" Height="80" Margin="0,10,0,0" Name="btnHide"/>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/test/VSSDK.TestExtension/ToolWindows/RunnerWindowControl.xaml.cs
+++ b/test/VSSDK.TestExtension/ToolWindows/RunnerWindowControl.xaml.cs
@@ -18,9 +18,14 @@ namespace TestExtension
             lblHeadline.Content = $"Visual Studio v{vsVersion}";
         }
 
-        private void button1_Click(object sender, RoutedEventArgs e)
+        private void btnShowMessage_Click(object sender, RoutedEventArgs e)
         {
             ShowMessageAsync().FireAndForget();
+        }
+
+        private void btnHide_Click(object sender, RoutedEventArgs e)
+        {
+            HideAsync().FireAndForget();
         }
 
         private async Task ShowMessageAsync()
@@ -34,6 +39,11 @@ namespace TestExtension
 
             VSConstants.MessageBoxResult button = await VS.MessageBox.ShowAsync("message", "title");
             Debug.WriteLine(button);
+        }
+
+        private async Task HideAsync()
+        {
+            await RunnerWindow.HideAsync();
         }
     }
 }


### PR DESCRIPTION
Related to #149 

I've created the `BaseToolWindow.HideAsync()` method which can be used to hide a tool window.

Example:
```cs
await RunnerWindow.HideAsync();
```