### PR TITLE
Added condition to only include the .cs files for C# style projects

### DIFF
--- a/src/toolkit/nuget/build/Community.VisualStudio.Toolkit.props
+++ b/src/toolkit/nuget/build/Community.VisualStudio.Toolkit.props
@@ -7,7 +7,7 @@
         <IncludeInVSIX>true</IncludeInVSIX>
       </Content>
 
-      <Compile Include="$(MSBuildThisFileDirectory)*.cs" />
+      <Compile Condition="'$(Language)'=='C#'" Include="$(MSBuildThisFileDirectory)*.cs" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
When you include the community project in a non c# project then this lines causes the build for that project to fail.
With the condition this is no longer a problem