### PR TITLE
Dynamic menu commands

### DIFF
--- a/demo/VSSDK.TestExtension/Commands/EditProjectFileCommand.cs
+++ b/demo/VSSDK.TestExtension/Commands/EditProjectFileCommand.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Community.VisualStudio.Toolkit;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace TestExtension.Commands
+{
+    [Command(PackageIds.EditProjectFile)]
+    internal sealed class EditProjectFileCommand : BaseDynamicCommand<EditProjectFileCommand, Project>
+    {
+        [SuppressMessage("Usage", "VSTHRD102:Implement internal logic asynchronously", Justification = "Must be synchronous.")]
+        protected override IReadOnlyList<Project> GetItems()
+        {
+            return ThreadHelper.JoinableTaskFactory.Run(async () =>
+            {
+                return (await VS.Solutions.GetAllProjectsAsync()).OrderBy(x => x.Name).ToList();
+            });
+        }
+
+        protected override void BeforeQueryStatus(OleMenuCommand menuItem, EventArgs e, Project project)
+        {
+            menuItem.Text = project.Name;
+        }
+
+        protected override async Task ExecuteAsync(OleMenuCmdEventArgs e, Project project)
+        {
+            try
+            {
+                await VS.Documents.OpenAsync(project.FullPath);
+            }
+            catch (COMException ex) when (ex.ErrorCode == -2147467259)
+            {
+                // The project needs to be unloaded before it
+                // can be opened. Get the GUID of the project.
+                project.GetItemInfo(out IVsHierarchy hierarchy, out _, out _);
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                IVsSolution solution = await VS.Services.GetSolutionAsync();
+                ErrorHandler.ThrowOnFailure(solution.GetGuidOfProject(hierarchy, out Guid guid));
+
+                // Unload the project.
+                ((IVsSolution4)solution).UnloadProject(guid, (uint)_VSProjectUnloadStatus.UNLOADSTATUS_UnloadedByUser);
+
+                // Now try to open the project file again.
+                await VS.Documents.OpenAsync(project.FullPath);
+            }
+        }
+    }
+
+}

--- a/demo/VSSDK.TestExtension/TestExtensionPackage.cs
+++ b/demo/VSSDK.TestExtension/TestExtensionPackage.cs
@@ -20,6 +20,7 @@ namespace VSSDK.TestExtension
     [ProvideFileIcon(".abc", "KnownMonikers.Reference")]
     [ProvideToolWindow(typeof(MultiInstanceWindow.Pane))]
     [ProvideMenuResource("Menus.ctmenu", 1)]
+    [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExists_string, PackageAutoLoadFlags.BackgroundLoad)]
     public sealed class TestExtensionPackage : ToolkitPackage
     {
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)

--- a/demo/VSSDK.TestExtension/VSCommandTable.cs
+++ b/demo/VSSDK.TestExtension/VSCommandTable.cs
@@ -22,8 +22,10 @@ namespace TestExtension
     {
         public const int TestExtensionMainMenu = 0x1000;
         public const int TestExtensionSolutionExplorerMenu = 0x1001;
+        public const int TestExtensionEditProjectFileMenu = 0x1002;
         public const int TestExtensionMainMenuGroup1 = 0x1100;
         public const int TestExtensionSolutionExplorerGroup = 0x1101;
+        public const int TestExtensionEditProjectFileGroup = 0x1102;
         public const int RunnerWindow = 0x0100;
         public const int ThemeWindow = 0x0101;
         public const int MultiInstanceWindow = 0x0102;
@@ -36,5 +38,6 @@ namespace TestExtension
         public const int ExpandSelectedItems = 0x0109;
         public const int CollapseSelectedItems = 0x0110;
         public const int ListReferences = 0x0111;
+        public const int EditProjectFile = 0x2001;
     }
 }

--- a/demo/VSSDK.TestExtension/VSCommandTable.vsct
+++ b/demo/VSSDK.TestExtension/VSCommandTable.vsct
@@ -5,7 +5,7 @@
   <Extern href="vsshlids.h"/>
   <Include href="KnownImageIds.vsct"/>
   <Include href="VSGlobals.vsct"/>
-  
+
   <Commands package="TestExtension">
     <!--This section defines the elements the user can interact with, like a menu command or a button
         or combo box in a toolbar. -->
@@ -24,18 +24,29 @@
           <ButtonText>Solution Explorer</ButtonText>
         </Strings>
       </Menu>
+
+      <Menu guid="TestExtension" id="TestExtensionEditProjectFileMenu" priority="0x0200" type="Menu">
+        <Parent guid="TestExtension" id="TestExtensionMainMenuGroup1" />
+        <Strings>
+          <ButtonText>Edit Project File</ButtonText>
+        </Strings>
+      </Menu>
     </Menus>
-    
+
     <Groups>
       <Group guid="TestExtension" id="TestExtensionMainMenuGroup1" priority="0x1100">
         <Parent guid="TestExtension" id="TestExtensionMainMenu" />
       </Group>
-      
+
       <Group guid="TestExtension" id="TestExtensionSolutionExplorerGroup" priority="0x1101">
         <Parent guid="TestExtension" id="TestExtensionSolutionExplorerMenu" />
       </Group>
+
+      <Group guid="TestExtension" id="TestExtensionEditProjectFileGroup" priority="0x1102">
+        <Parent guid="TestExtension" id="TestExtensionEditProjectFileMenu" />
+      </Group>
     </Groups>
-    
+
     <Buttons>
       <Button guid="TestExtension" id="RunnerWindow" priority="0x0105" type="Button">
         <Parent guid="VSMainMenu" id="View.DevWindowsGroup.OtherWindows.Group1"/>
@@ -99,7 +110,18 @@
           <ButtonText>List References</ButtonText>
         </Strings>
       </Button>
-      
+
+      <Button guid="TestExtension" id="EditProjectFile" priority="0x0103" type="Button">
+        <Parent guid="TestExtension" id="TestExtensionEditProjectFileGroup"/>
+        <CommandFlag>DynamicItemStart</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>TextChanges</CommandFlag>
+        <Strings>
+          <ButtonText>Loading...</ButtonText>
+        </Strings>
+      </Button>
+
       <Button guid="TestExtension" id="ToggleVsixManifestFilter" priority="0x0100" type="Button">
         <Parent guid="TestExtension" id="TestExtensionSolutionExplorerGroup"/>
         <Icon guid="ImageCatalogGuid" id="VisualStudioSettingsFile" />
@@ -139,12 +161,19 @@
     </Buttons>
   </Commands>
 
+  <VisibilityConstraints>
+    <VisibilityItem guid="TestExtension" id="EditProjectFile" context="UICONTEXT_SolutionExists" />
+  </VisibilityConstraints>
+
   <Symbols>
     <GuidSymbol name="TestExtension" value="{05271709-8845-42fb-9d10-621cc8cffc5d}">
       <IDSymbol name="TestExtensionMainMenu" value="0x1000" />
       <IDSymbol name="TestExtensionSolutionExplorerMenu" value="0x1001" />
+      <IDSymbol name="TestExtensionEditProjectFileMenu" value="0x1002" />
+
       <IDSymbol name="TestExtensionMainMenuGroup1" value="0x1100" />
       <IDSymbol name="TestExtensionSolutionExplorerGroup" value="0x1101" />
+      <IDSymbol name="TestExtensionEditProjectFileGroup" value="0x1102" />
 
       <IDSymbol name="RunnerWindow" value="0x0100" />
       <IDSymbol name="ThemeWindow" value="0x0101" />
@@ -158,6 +187,8 @@
       <IDSymbol name="ExpandSelectedItems" value="0x0109" />
       <IDSymbol name="CollapseSelectedItems" value="0x0110" />
       <IDSymbol name="ListReferences" value="0x0111" />
+
+      <IDSymbol name="EditProjectFile" value="0x2001" />
     </GuidSymbol>
   </Symbols>
 </CommandTable>

--- a/demo/VSSDK.TestExtension/VSSDK.TestExtension.csproj
+++ b/demo/VSSDK.TestExtension/VSSDK.TestExtension.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Commands\BuildActiveProjectAsyncCommand.cs" />
     <Compile Include="Commands\BuildSolutionAsyncCommand.cs" />
     <Compile Include="Commands\CollapseSelectedItemsCommand.cs" />
+    <Compile Include="Commands\EditProjectFileCommand.cs" />
     <Compile Include="Commands\ExpandSelectedItemsCommand.cs" />
     <Compile Include="Commands\ListReferencesCommand.cs" />
     <Compile Include="Commands\MultiInstanceWindowCommand.cs" />

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Commands/BaseDynamicCommand.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Commands/BaseDynamicCommand.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+namespace Community.VisualStudio.Toolkit
+{
+    /// <summary>
+    /// A base class that makes it easier to handle dynamic menu commands.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// [Command("a4477648-9ba7-4bbc-af04-8b7e931f88ab", 0x0100)]
+    /// public class TestCommand : BaseDynamicCommand&lt;TestCommand, MyObject&gt;
+    /// {
+    ///     protected async override Task ExecuteAsync(OleMenuCmdEventArgs e, MyObject item)
+    ///     {
+    ///         await item.DoSomethingAsync();
+    ///     }
+    /// }
+    /// </code>
+    /// </example>
+    /// <typeparam name="TCommand">The implementation type itself.</typeparam>
+    /// <typeparam name="TItem">The type of item that a menu item is dynamically created for.</typeparam>
+    public abstract class BaseDynamicCommand<TCommand, TItem> : BaseCommand<TCommand>, IBaseDynamicCommand where TCommand : class, new()
+    {
+        private static readonly object _dynamicMenuItemKey = new();
+
+        private IReadOnlyList<TItem>? _items;
+
+        /// <summary>
+        /// Gets the items that the menu items will be created for. One menu item will be created for each item that is returned.
+        /// </summary>
+        protected abstract IReadOnlyList<TItem> GetItems();
+
+        bool IBaseDynamicCommand.IsMatch(int commandId)
+        {
+            int index = commandId - Command.CommandID.ID;
+            return TryGetItem(index, out _);
+        }
+
+        /// <inheritdoc/>
+        internal sealed override void BeforeQueryStatus(object sender, EventArgs e)
+        {
+            DynamicItemMenuCommand menuItem = (DynamicItemMenuCommand)sender;
+            int index;
+
+            if (Command.MatchedCommandId == 0)
+            {
+                // The matched command ID will be zero for the base item. The base item is always
+                // called first, then `IsMatch` is called repeatedly with increasing command IDs
+                // until it returns false. In `IsMatch`, we return use the count of items to
+                // determine when to stop, so this is the perfect opportunity to get the latest
+                // items so that the dynamic menu items reflect the latest set of items.
+                index = 0;
+                _items = GetItems();
+            }
+            else
+            {
+                // For all other items, the matched command ID
+                // will be the base command ID plus the index.
+                index = Command.MatchedCommandId - Command.CommandID.ID;
+            }
+
+            // There may be no items, but we'll always be called for the base 
+            // item, which means the index could be out of bounds. If the index
+            // is out of bounds, then we'll hide and disable the menu item.
+            if (TryGetItem(index, out TItem item))
+            {
+                BeforeQueryStatus(menuItem, e, item);
+
+                // Store the index in the menu item's properties so that we can
+                // determine the index of the menu item when it is executed.
+                menuItem.Properties[_dynamicMenuItemKey] = index;
+            }
+            else
+            {
+                menuItem.Enabled = false;
+                menuItem.Visible = false;
+                menuItem.Properties.Remove(_dynamicMenuItemKey);
+            }
+
+            // We have finished handling this item, so clear
+            // the matched command ID on the base command.
+            Command.MatchedCommandId = 0;
+        }
+
+        /// <summary>Override this method to control the commands visibility and other properties.</summary>
+        protected abstract void BeforeQueryStatus(OleMenuCommand menuItem, EventArgs e, TItem item);
+
+        /// <inheritdoc/>
+        protected override sealed void Execute(object sender, EventArgs e)
+        {
+            DynamicItemMenuCommand menuItem = (DynamicItemMenuCommand)sender;
+            if (menuItem.Properties.Contains(_dynamicMenuItemKey))
+            {
+                int index = (int)menuItem.Properties[_dynamicMenuItemKey];
+                if (TryGetItem(index, out TItem item))
+                {
+                    Execute((OleMenuCmdEventArgs)e, item);
+                }
+            }
+        }
+
+        /// <summary>Executes synchronously when the command is invoked.</summary>
+        /// <remarks>
+        /// Use this method instead of <see cref="ExecuteAsync(OleMenuCmdEventArgs, TItem)"/> if you're not performing any async tasks using async/await patterns.
+        /// </remarks>
+        protected virtual void Execute(OleMenuCmdEventArgs e, TItem item)
+        {
+            Package.JoinableTaskFactory.RunAsync(async delegate
+            {
+                try
+                {
+                    await ExecuteAsync(e, item);
+                }
+                catch (Exception ex)
+                {
+                    await ex.LogAsync();
+                }
+            }).FireAndForget();
+        }
+
+        /// <summary>Executes asynchronously when the command is invoked and <see cref="Execute(object, EventArgs)"/> isn't overridden.</summary>
+        /// <remarks>Use this method instead of <see cref="Execute(OleMenuCmdEventArgs, TItem)"/> if you're invoking any async tasks by using async/await patterns.</remarks>
+        protected virtual Task ExecuteAsync(OleMenuCmdEventArgs e, TItem item)
+        {
+            return Task.CompletedTask;
+        }
+
+        private bool TryGetItem(int index, out TItem item)
+        {
+            if (_items is null)
+            {
+                item = default!;
+                return false;
+            }
+
+            if ((index >= 0) && (index < _items.Count))
+            {
+                item = _items[index];
+                return true;
+            }
+
+            item = default!;
+            return false;
+        }
+
+        /// <inheritdoc/>
+        protected override sealed void BeforeQueryStatus(EventArgs e)
+        {
+            // This method will not be called for dynamic commands. This is
+            // sealed to prevent consumers from unnecessarily overriding it.
+        }
+
+        /// <inheritdoc/>
+        protected override sealed Task ExecuteAsync(OleMenuCmdEventArgs e)
+        {
+            // This method will not be called for dynamic commands. This is
+            // sealed to prevent consumers from unnecessarily overriding it.
+            return Task.CompletedTask;
+        }
+    }
+
+    internal interface IBaseDynamicCommand
+    {
+        bool IsMatch(int commandId);
+    }
+}

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Commands/DynamicItemMenuCommand.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Commands/DynamicItemMenuCommand.cs
@@ -1,0 +1,28 @@
+using System;
+using System.ComponentModel.Design;
+using Microsoft.VisualStudio.Shell;
+
+namespace Community.VisualStudio.Toolkit
+{
+    internal class DynamicItemMenuCommand : OleMenuCommand
+    {
+        private readonly Func<int, bool> _isMatch;
+
+        public DynamicItemMenuCommand(Func<int, bool> isMatch, EventHandler invoke, EventHandler beforeQueryStatus, CommandID id) : base(invoke, changeHandler: null, beforeQueryStatus, id)
+        {
+            _isMatch = isMatch;
+        }
+
+        public override bool DynamicItemMatch(int cmdId)
+        {
+            if (_isMatch(cmdId))
+            {
+                MatchedCommandId = cmdId;
+                return true;
+            }
+
+            MatchedCommandId = 0;
+            return false;
+        }
+    }
+}

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
@@ -83,6 +83,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Solution\Solutions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows\Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Commands\BaseCommand.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Commands\BaseDynamicCommand.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Commands\DynamicItemMenuCommand.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Notifications\StatusBar.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR adds the ability to define [dynamic menu commands](https://docs.microsoft.com/visualstudio/extensibility/dynamically-adding-menu-items).

### API

To define a dynamic menu command, inherit from `BaseDymanicCommand`. This is very similar to how you would define a static command (in fact, `BaseDymanicCommand` inherits from `BaseCommand`). This class requires two generic arguments. The first is the type of the command (the same as what `BaseCommand` requires), and the second is the type of object that each menu item will be created for. 

For example, if you wanted to create a menu item for each project in the solution, then you could define your command like this:

```cs
class EditProjectFileCommand : BaseDynamicCommand<EditProjectFileCommand, Project> {
    // ...
}
```

There are three methods that you must override:

#### `GetItems`

Override `GetItems` and return a list of items that correspond to the menu items that you want to create. One menu item will be created for each item, in the order provided in the list. Using our example of creating a menu item for each project, you could override the method like this:

```cs
protected override IReadOnlyList<Project> GetItems()
{
    return ThreadHelper.JoinableTaskFactory.Run(async () =>
    {
        return (await VS.Solutions.GetAllProjectsAsync()).OrderBy(x => x.Name).ToList();
    });
}
```

#### `BeforeQueryStatus`
The `BeforeQueryStatus` method will be called for each item returned from `GetItems`. Unline `BaseCommand`, you _must_ override this method, because this is your opportunity to set the text of the menu item.

```cs
protected override void BeforeQueryStatus(OleMenuCommand menuItem, EventArgs e, Project project)
{
    menuItem.Text = project.Name;
}
```

#### `Execute` or `ExecuteAsync`

Just like `BaseCommand`, you have a choice between overriding the async or non-async execute method. Whichever one you choose, the method will be called with the item that corresponds to the menu item.

```cs
protected override async Task ExecuteAsync(OleMenuCmdEventArgs e, Project project)
{
    await VS.Documents.OpenAsync(project.FullPath);
}
```

----

So all up, a complete dynamic command can be defined like this:

```cs
[Command(PackageIds.EditProjectFile)]
internal sealed class EditProjectFileCommand : BaseDynamicCommand<EditProjectFileCommand, Project>
{
    protected override IReadOnlyList<Project> GetItems()
    {
        return ThreadHelper.JoinableTaskFactory.Run(async () =>
        {
            return (await VS.Solutions.GetAllProjectsAsync()).OrderBy(x => x.Name).ToList();
        });
    }

    protected override void BeforeQueryStatus(OleMenuCommand menuItem, EventArgs e, Project project)
    {
        menuItem.Text = project.Name;
    }

    protected override async Task ExecuteAsync(OleMenuCmdEventArgs e, Project project)
    {
        await VS.Documents.OpenAsync(project.FullPath);
    }
}
```

And, of course, you'll need to add the appropriate definition to the `.vsct` file. The important bit is to set the `DynamicItemStart` command flag.

```xml
<Button guid="TestExtension" id="EditProjectFile" priority="0x0103" type="Button">
  <Parent guid="TestExtension" id="TestExtensionEditProjectFileGroup"/>
  <CommandFlag>DynamicItemStart</CommandFlag> <!-- This is the important bit! -->
  <CommandFlag>DynamicVisibility</CommandFlag>
  <CommandFlag>DefaultInvisible</CommandFlag>
  <CommandFlag>TextChanges</CommandFlag>
  <Strings>
    <ButtonText>Loading...</ButtonText>
  </Strings>
</Button>
```