### PR TITLE
Improved unloaded project support

### DIFF
--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/IVsSolutionExtensions.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/IVsSolutionExtensions.cs
@@ -37,16 +37,28 @@ namespace Microsoft.VisualStudio.Shell.Interop
         /// <summary>
         /// Gets all projects in the solution as IVsHierarchy items.
         /// </summary>
-        public static IEnumerable<IVsHierarchy> GetAllProjectHierarchys(this IVsSolution solution)
+        public static IEnumerable<IVsHierarchy> GetAllProjectHierarchies(this IVsSolution solution, ProjectStateFilter filter = ProjectStateFilter.Loaded)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            return GetAllProjectHierarchys(solution, __VSENUMPROJFLAGS.EPF_LOADEDINSOLUTION);
+            
+            __VSENUMPROJFLAGS flags = 0;
+            if ((filter & ProjectStateFilter.Loaded) == ProjectStateFilter.Loaded)
+            {
+                flags |= __VSENUMPROJFLAGS.EPF_LOADEDINSOLUTION;
+            }
+
+            if ((filter & ProjectStateFilter.Unloaded) == ProjectStateFilter.Unloaded)
+            {
+                flags |= __VSENUMPROJFLAGS.EPF_UNLOADEDINSOLUTION;
+            }
+
+            return GetAllProjectHierarchies(solution, flags);
         }
 
         /// <summary>
         /// Gets all projects in the solution as IVsHierarchy items.
         /// </summary>
-        public static IEnumerable<IVsHierarchy> GetAllProjectHierarchys(this IVsSolution solution, __VSENUMPROJFLAGS flags)
+        public static IEnumerable<IVsHierarchy> GetAllProjectHierarchies(this IVsSolution solution, __VSENUMPROJFLAGS flags)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
@@ -78,7 +90,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
         public static async Task<SolutionItem?> ToSolutionItemAsync(this IVsSolution solution)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            
+
             if (solution is IVsHierarchy hier)
             {
                 IVsHierarchyItem? item = await hier.ToHierarchyItemAsync(VSConstants.VSITEMID_ROOT);

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Solution/ProjectStateFilter.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Solution/ProjectStateFilter.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace Community.VisualStudio.Toolkit
+{
+    /// <summary>
+    /// Defines the different project states that can be used to filter projects.
+    /// </summary>
+    [Flags]
+    public enum ProjectStateFilter
+    {
+        /// <summary>
+        /// No projects.
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// Projects that are currently loaded.
+        /// </summary>
+        Loaded = 1,
+        /// <summary>
+        /// Projects that are currently unloaded.
+        /// </summary>
+        Unloaded = 2,
+        /// <summary>
+        /// Both loaded and unloaded projects.
+        /// </summary>
+        All = Loaded | Unloaded
+    }
+}

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Solution/SolutionItem.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Solution/SolutionItem.cs
@@ -161,6 +161,11 @@ namespace Community.VisualStudio.Toolkit
             {
                 return SolutionItemType.Project;
             }
+            else if (HierarchyUtilities.IsStubHierarchy(identity))
+            {
+                // This is most likely an unloaded project.
+                return SolutionItemType.Project;
+            }
             else if (HierarchyUtilities.IsPhysicalFile(identity))
             {
                 return SolutionItemType.PhysicalFile;

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Solution/Solutions.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Solution/Solutions.cs
@@ -63,21 +63,21 @@ namespace Community.VisualStudio.Toolkit
         /// <summary>
         /// Gets all projects in the solution.
         /// </summary>
-        public async Task<IEnumerable<IVsHierarchy>> GetAllProjectHierarchiesAsync()
+        public async Task<IEnumerable<IVsHierarchy>> GetAllProjectHierarchiesAsync(ProjectStateFilter filter = ProjectStateFilter.Loaded)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             IVsSolution sol = await VS.Services.GetSolutionAsync();
-            return sol.GetAllProjectHierarchys();
+            return sol.GetAllProjectHierarchies(filter);
         }
 
         /// <summary>
         /// Gets all projects in the solution
         /// </summary>
-        public async Task<IEnumerable<Project>> GetAllProjectsAsync()
+        public async Task<IEnumerable<Project>> GetAllProjectsAsync(ProjectStateFilter filter = ProjectStateFilter.Loaded)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             IVsSolution solution = await VS.Services.GetSolutionAsync();
-            IEnumerable<IVsHierarchy> hierarchies = solution.GetAllProjectHierarchys();
+            IEnumerable<IVsHierarchy> hierarchies = solution.GetAllProjectHierarchies(filter);
 
             List<Project> list = new();
 

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
@@ -38,6 +38,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Solution\VirtualFolder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Solution\PhysicalFile.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Solution\Project.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Solution\ProjectStateFilter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Solution\Solution.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Solution\SolutionFolder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Solution\SolutionItemType.cs" />


### PR DESCRIPTION
Fixes #191.

Changes:

* `ProjectStateFilter` is an enum that lets you choose between getting loaded, unloaded or all projects.
* `Solutions.GetAllProjectHierarchiesAsync` and `Solutions.GetAllProjectsAsync` now have an optional `ProjectStateFilter` property. The default is `Loaded` to match the previous behavior.
* `IVsSolutionExtensions.GetAllProjectHierarchies` also takes a `ProjectStateFilter`, which is converted to the corresponding `__VSENUMPROJFLAGS` value. The overload that takes a `__VSENUMPROJFLAGS` still exists.
* When getting the type for a `SolutionItem`, a "stub hierarchy" is treated as a project.