### PR TITLE
Made SolutionItem.Name and FullPath read-only

### DIFF
--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Solution/SolutionItem.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Solution/SolutionItem.cs
@@ -33,20 +33,24 @@ namespace Community.VisualStudio.Toolkit
             _hierarchy = item.HierarchyIdentity.IsNestedItem ? item.HierarchyIdentity.NestedHierarchy : item.HierarchyIdentity.Hierarchy;
             _itemId = item.HierarchyIdentity.IsNestedItem ? item.HierarchyIdentity.NestedItemID : item.HierarchyIdentity.ItemID;
 
-            Name = item.Text;
             Type = type;
             FullPath = GetFullPath();
         }
 
         /// <summary>
-        /// The display name of the item.
+        /// The name of the item.
         /// </summary>
-        public string Name { get; set; }
+        public string Name => _item.CanonicalName;
+
+        /// <summary>
+        /// The display text of the item.
+        /// </summary>
+        public string Text => _item.Text;
 
         /// <summary>
         /// The absolute file path on disk.
         /// </summary>
-        public string? FullPath { get; set; }
+        public string? FullPath { get; }
 
         /// <summary>
         /// The type of solution item.


### PR DESCRIPTION
I've also changed `Name` to return the `IVsHierarchy.CanonicalName` property rather than the `Text` property. I've added a `Text` property to get the hierarchy text.

The only difference I've been able to find between `CanonicalName` and `Text` is when a project is unloaded. For an unloaded project the `CanonicalName` will be "ProjectName", but the `Text` will be "ProjectName (unloaded)". 

I'm happy to revert the `Name` property back to returning the `IVsHierarcny.Text` if you think that would be better.

Fixes #198.