### PR TITLE
Update SingleFileGeneratorTypes.cs

### DIFF
--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Helpers/SingleFileGeneratorTypes.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Helpers/SingleFileGeneratorTypes.cs
@@ -10,7 +10,7 @@ namespace Community.VisualStudio.Toolkit
     /// [Guid("Guid-For-Your-IVsSingleFileGenerator")] <br/>
     /// [ComVisible(true)] <br/>
     /// [ProvideObject(typeof(YourCustomToolClass))] <br/>
-    /// [CodeGeneratorRegistration(typeof(YourCustomToolClass), "NameOfCustomTool", SingleFileGeneratorTypes.CSHARP, GeneratesDesignTimeSource = true, GeneratorRegKeyName = "CustomTool for C#")] <br/>
+    /// [CodeGeneratorRegistration(typeof(YourCustomToolClass), "NameOfCustomTool", SingleFileGeneratorTypes.CSHARP)] <br/>
     /// </remarks>
     public static class SingleFileGeneratorTypes
     {


### PR DESCRIPTION
I thought that adding the GeneratorRegKeyName would add a description to the registry when registering. Instead it broke it completely. (Debugging in test instance it worked, but when the vsix was installed manually it failed to register.)

I'm removing the suggestion to have it in there since it doesn't work with that segment installed.