### PR TITLE
Fixed showing an Info Bar on a window via the window GUID

### DIFF
--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Notifications/InfoBar.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Notifications/InfoBar.cs
@@ -62,7 +62,7 @@ namespace Community.VisualStudio.Toolkit
                 // Do nothing, the 'frame' is assigned
             }
 
-            return null;
+            return frame;
         }
     }
 


### PR DESCRIPTION
`GetFrameFromIdentifierAsync` always returned null, so `CreateAsync(string, InfoBarModel)` would never find the `IVsWindowFrame` and therefore would never create the `InfoBar`.