### PR TITLE
Methods to load and unload projects

### DIFF
--- a/demo/VSSDK.TestExtension/Commands/LoadSelectedProject.cs
+++ b/demo/VSSDK.TestExtension/Commands/LoadSelectedProject.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using Community.VisualStudio.Toolkit;
+using Microsoft.VisualStudio.Shell;
+
+namespace TestExtension.Commands
+{
+    [Command(PackageIds.LoadSelectedProject)]
+    internal sealed class LoadSelectedProjectCommand : BaseCommand<LoadSelectedProjectCommand>
+    {
+        protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            Project project = await VS.Solutions.GetActiveProjectAsync();
+            if (project != null)
+            {
+                await project.LoadAsync();
+                
+                // Show a message to demonstrate that the Project object can still be used.
+                await VS.MessageBox.ShowAsync($"Project '{project.Name}' has been loaded.");
+            }
+        }
+    }
+}

--- a/demo/VSSDK.TestExtension/Commands/UnloadSelectedProject.cs
+++ b/demo/VSSDK.TestExtension/Commands/UnloadSelectedProject.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using Community.VisualStudio.Toolkit;
+using Microsoft.VisualStudio.Shell;
+
+namespace TestExtension.Commands
+{
+    [Command(PackageIds.UnloadSelectedProject)]
+    internal sealed class UnloadSelectedProjectCommand : BaseCommand<UnloadSelectedProjectCommand>
+    {
+        protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            Project project = await VS.Solutions.GetActiveProjectAsync();
+            if (project != null)
+            {
+                await project.UnloadAsync();
+
+                // Show a message to demonstrate that the Project object can still be used.
+                await VS.MessageBox.ShowAsync($"Project '{project.Name}' has been unloaded.");
+            }
+        }
+    }
+}

--- a/demo/VSSDK.TestExtension/VSCommandTable.cs
+++ b/demo/VSSDK.TestExtension/VSCommandTable.cs
@@ -38,6 +38,8 @@ namespace TestExtension
         public const int ExpandSelectedItems = 0x0109;
         public const int CollapseSelectedItems = 0x0110;
         public const int ListReferences = 0x0111;
+        public const int LoadSelectedProject = 0x0112;
+        public const int UnloadSelectedProject = 0x0113;
         public const int EditProjectFile = 0x2001;
     }
 }

--- a/demo/VSSDK.TestExtension/VSCommandTable.vsct
+++ b/demo/VSSDK.TestExtension/VSCommandTable.vsct
@@ -25,7 +25,7 @@
         </Strings>
       </Menu>
 
-      <Menu guid="TestExtension" id="TestExtensionEditProjectFileMenu" priority="0x0200" type="Menu">
+      <Menu guid="TestExtension" id="TestExtensionEditProjectFileMenu" priority="0x0201" type="Menu">
         <Parent guid="TestExtension" id="TestExtensionMainMenuGroup1" />
         <Strings>
           <ButtonText>Edit Project File</ButtonText>
@@ -111,7 +111,21 @@
         </Strings>
       </Button>
 
-      <Button guid="TestExtension" id="EditProjectFile" priority="0x0103" type="Button">
+      <Button guid="TestExtension" id="LoadSelectedProject" priority="0x0103" type="Button">
+        <Parent guid="TestExtension" id="TestExtensionMainMenuGroup1"/>
+        <Strings>
+          <ButtonText>Load Selected Project</ButtonText>
+        </Strings>
+      </Button>
+
+      <Button guid="TestExtension" id="UnloadSelectedProject" priority="0x0104" type="Button">
+        <Parent guid="TestExtension" id="TestExtensionMainMenuGroup1"/>
+        <Strings>
+          <ButtonText>Unload Selected Project</ButtonText>
+        </Strings>
+      </Button>
+      
+      <Button guid="TestExtension" id="EditProjectFile" priority="0x0105" type="Button">
         <Parent guid="TestExtension" id="TestExtensionEditProjectFileGroup"/>
         <CommandFlag>DynamicItemStart</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
@@ -187,6 +201,8 @@
       <IDSymbol name="ExpandSelectedItems" value="0x0109" />
       <IDSymbol name="CollapseSelectedItems" value="0x0110" />
       <IDSymbol name="ListReferences" value="0x0111" />
+      <IDSymbol name="LoadSelectedProject" value="0x0112" />
+      <IDSymbol name="UnloadSelectedProject" value="0x0113" />
 
       <IDSymbol name="EditProjectFile" value="0x2001" />
     </GuidSymbol>

--- a/demo/VSSDK.TestExtension/VSSDK.TestExtension.csproj
+++ b/demo/VSSDK.TestExtension/VSSDK.TestExtension.csproj
@@ -52,12 +52,14 @@
     <Compile Include="Commands\EditProjectFileCommand.cs" />
     <Compile Include="Commands\ExpandSelectedItemsCommand.cs" />
     <Compile Include="Commands\ListReferencesCommand.cs" />
+    <Compile Include="Commands\LoadSelectedProject.cs" />
     <Compile Include="Commands\MultiInstanceWindowCommand.cs" />
     <Compile Include="Commands\EditSelectedItemLabelCommand.cs" />
     <Compile Include="Commands\SelectCurrentProjectCommand.cs" />
     <Compile Include="Commands\ToggleVsixManifestFilterCommand.cs" />
     <Compile Include="Commands\RunnerWindowCommand.cs" />
     <Compile Include="Commands\ThemeWindowCommand.cs" />
+    <Compile Include="Commands\UnloadSelectedProject.cs" />
     <Compile Include="MEF\TextViewCreationListener.cs" />
     <Compile Include="Options\General.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Solution/SolutionItem.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Solution/SolutionItem.cs
@@ -18,9 +18,10 @@ namespace Community.VisualStudio.Toolkit
     {
         private SolutionItem? _parent;
         private IEnumerable<SolutionItem?>? _children;
-        private readonly IVsHierarchyItem _item;
-        private readonly IVsHierarchy _hierarchy;
-        private readonly uint _itemId;
+        private IVsHierarchyItem _item = default!; // Initialized to non-null via the `Update()` method.
+        private IVsHierarchy _hierarchy = default!; // Initialized to non-null via the `Update()` method.
+        private string? _fullPath;
+        private uint _itemId;
 
         /// <summary>
         /// Creates a new instance of the solution item.
@@ -28,13 +29,17 @@ namespace Community.VisualStudio.Toolkit
         protected SolutionItem(IVsHierarchyItem item, SolutionItemType type)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
-            _item = item;
+            Type = type;
+            Update(item);
+        }
 
+        internal void Update(IVsHierarchyItem item)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+            _item = item;
             _hierarchy = item.HierarchyIdentity.IsNestedItem ? item.HierarchyIdentity.NestedHierarchy : item.HierarchyIdentity.Hierarchy;
             _itemId = item.HierarchyIdentity.IsNestedItem ? item.HierarchyIdentity.NestedItemID : item.HierarchyIdentity.ItemID;
-
-            Type = type;
-            FullPath = GetFullPath();
+            _fullPath = GetFullPath();
         }
 
         /// <summary>
@@ -50,7 +55,7 @@ namespace Community.VisualStudio.Toolkit
         /// <summary>
         /// The absolute file path on disk.
         /// </summary>
-        public string? FullPath { get; }
+        public string? FullPath => _fullPath;
 
         /// <summary>
         /// The type of solution item.


### PR DESCRIPTION
The `Project` class now has some additional methods to load and unload projects.

Load a project:
```cs
await project.LoadAsync();
```

Unload a project:
```cs
await project.UnloadAsync();
```

Check if a project is loaded:
```cs
if (project.IsLoaded) { }
```

Loading or unloading a project seems to dispose of the underlying `IVsHierarchy` object, so I've added an internal `SolutionItem.Update()` method that can be used to give the SolutionItem a new `IVsHierarchyItem`.

I've also added a couple of commands to the demo extension to demonstrate the new functionality.