### PR TITLE
Example of adding a toolbar to a tool window

### DIFF
--- a/demo/VSSDK.TestExtension/Commands/SendMessageToRunnerWindowCommand.cs
+++ b/demo/VSSDK.TestExtension/Commands/SendMessageToRunnerWindowCommand.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+using Community.VisualStudio.Toolkit;
+using Microsoft.VisualStudio.Shell;
+
+namespace TestExtension
+{
+    [Command(PackageIds.SendMessageToRunnerWindow)]
+    internal sealed class SendMessageToRunnerWindowCommand : BaseCommand<SendMessageToRunnerWindowCommand>
+    {
+        private int _counter;
+
+        protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            RunnerWindowMessenger messenger = await Package.GetServiceAsync<RunnerWindowMessenger, RunnerWindowMessenger>();
+            _counter += 1;
+            messenger.Send($"Message #{_counter}");
+        }
+    }
+}

--- a/demo/VSSDK.TestExtension/TestExtensionPackage.cs
+++ b/demo/VSSDK.TestExtension/TestExtensionPackage.cs
@@ -21,10 +21,13 @@ namespace VSSDK.TestExtension
     [ProvideToolWindow(typeof(MultiInstanceWindow.Pane))]
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExists_string, PackageAutoLoadFlags.BackgroundLoad)]
+    [ProvideService(typeof(RunnerWindowMessenger), IsAsyncQueryable = true)]
     public sealed class TestExtensionPackage : ToolkitPackage
     {
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
+            AddService(typeof(RunnerWindowMessenger), (_, _, _) => Task.FromResult<object>(new RunnerWindowMessenger()));
+
             // Tool windows
             this.RegisterToolWindows();
 
@@ -41,7 +44,6 @@ namespace VSSDK.TestExtension
             VS.Events.SolutionEvents.OnBeforeOpenProject += SolutionEvents_OnBeforeOpenProject;
             VS.Events.BuildEvents.ProjectConfigurationChanged += BuildEvents_ProjectConfigurationChanged;
             VS.Events.BuildEvents.SolutionConfigurationChanged += BuildEvents_SolutionConfigurationChanged;
-
         }
 
         private void BuildEvents_SolutionConfigurationChanged()
@@ -58,7 +60,7 @@ namespace VSSDK.TestExtension
 
         }
 
-         private void SolutionEvents_OnBeforeOpenProject(string obj)
+        private void SolutionEvents_OnBeforeOpenProject(string obj)
         {
             VS.StatusBar.ShowMessageAsync("About to open " + obj).FireAndForget();
         }

--- a/demo/VSSDK.TestExtension/ToolWindows/RunnerWindow.cs
+++ b/demo/VSSDK.TestExtension/ToolWindows/RunnerWindow.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel.Design;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,7 +19,8 @@ namespace TestExtension
         public override async Task<FrameworkElement> CreateAsync(int toolWindowId, CancellationToken cancellationToken)
         {
             Version version = await VS.Shell.GetVsVersionAsync();
-            return new RunnerWindowControl(version);
+            RunnerWindowMessenger messenger = await Package.GetServiceAsync<RunnerWindowMessenger, RunnerWindowMessenger>();
+            return new RunnerWindowControl(version, messenger);
         }
 
         [Guid("d3b3ebd9-87d1-41cd-bf84-268d88953417")]
@@ -27,6 +29,7 @@ namespace TestExtension
             public Pane()
             {
                 BitmapImageMoniker = KnownMonikers.StatusInformation;
+                ToolBar = new CommandID(PackageGuids.TestExtension, PackageIds.RunnerWindowToolbar);
             }
         }
     }

--- a/demo/VSSDK.TestExtension/ToolWindows/RunnerWindowControl.xaml
+++ b/demo/VSSDK.TestExtension/ToolWindows/RunnerWindowControl.xaml
@@ -9,10 +9,21 @@
              d:DesignHeight="300" d:DesignWidth="300"
              Name="MyToolWindow">
     <Grid>
-        <StackPanel Orientation="Vertical">
-            <Label Name="lblHeadline" Margin="10" HorizontalAlignment="Center">Runner Window</Label>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <Label Name="lblHeadline" Grid.Row="0" HorizontalAlignment="Center" Margin="0,10,0,0">Runner Window</Label>
+        
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10">
             <Button Content="Show a message" Click="btnShowMessage_Click" Width="120" Height="80" Name="btnShowMessage"/>
-            <Button Content="Hide me" Click="btnHide_Click" Width="120" Height="80" Margin="0,10,0,0" Name="btnHide"/>
+            <Button Content="Hide me" Click="btnHide_Click" Width="120" Height="80" Margin="10,0,0,0" Name="btnHide"/>
         </StackPanel>
+
+        <TextBlock Grid.Row="2" Text="Messages:" Margin="3,0,0,3"/>
+        <ListBox x:Name="MessageList" Grid.Row="3" BorderThickness="1"/>
     </Grid>
 </UserControl>

--- a/demo/VSSDK.TestExtension/ToolWindows/RunnerWindowControl.xaml.cs
+++ b/demo/VSSDK.TestExtension/ToolWindows/RunnerWindowControl.xaml.cs
@@ -11,11 +11,18 @@ namespace TestExtension
 {
     public partial class RunnerWindowControl : UserControl
     {
-        public RunnerWindowControl(Version vsVersion)
+        public RunnerWindowControl(Version vsVersion, RunnerWindowMessenger messenger)
         {
             InitializeComponent();
 
             lblHeadline.Content = $"Visual Studio v{vsVersion}";
+
+            messenger.MessageReceived += OnMessageReceived;
+        }
+
+        private void OnMessageReceived(object sender, string e)
+        {
+            MessageList.Items.Add(e);
         }
 
         private void btnShowMessage_Click(object sender, RoutedEventArgs e)

--- a/demo/VSSDK.TestExtension/ToolWindows/RunnerWindowMessenger.cs
+++ b/demo/VSSDK.TestExtension/ToolWindows/RunnerWindowMessenger.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace TestExtension
+{
+    /// <summary>
+    /// This service demonstrates a very simple way for a toolbar to communicate 
+    /// with a tool window. There are many ways that this can be done, and this
+    /// service is by no means "best practice".
+    /// 
+    /// In fact, there is nothing about this service that restricts its use 
+    /// to toolbars and tool windows - it's just raising events. Any sort of
+    /// "message passing" can also be used to communicate with the tool window.
+    /// 
+    public class RunnerWindowMessenger
+    {
+        public void Send(string message)
+        {
+            // The tooolbar button will call this method.
+            // The tool window has added an event handler
+            MessageReceived?.Invoke(this, message);
+        }
+
+        public event EventHandler<string> MessageReceived;
+    }
+}

--- a/demo/VSSDK.TestExtension/VSCommandTable.cs
+++ b/demo/VSSDK.TestExtension/VSCommandTable.cs
@@ -26,6 +26,7 @@ namespace TestExtension
         public const int TestExtensionMainMenuGroup1 = 0x1100;
         public const int TestExtensionSolutionExplorerGroup = 0x1101;
         public const int TestExtensionEditProjectFileGroup = 0x1102;
+        public const int RunnerWindowToolbarGroup = 0x1103;
         public const int RunnerWindow = 0x0100;
         public const int ThemeWindow = 0x0101;
         public const int MultiInstanceWindow = 0x0102;
@@ -40,6 +41,8 @@ namespace TestExtension
         public const int ListReferences = 0x0111;
         public const int LoadSelectedProject = 0x0112;
         public const int UnloadSelectedProject = 0x0113;
+        public const int SendMessageToRunnerWindow = 0x0114;
         public const int EditProjectFile = 0x2001;
+        public const int RunnerWindowToolbar = 0x0BB8;
     }
 }

--- a/demo/VSSDK.TestExtension/VSCommandTable.vsct
+++ b/demo/VSSDK.TestExtension/VSCommandTable.vsct
@@ -31,6 +31,13 @@
           <ButtonText>Edit Project File</ButtonText>
         </Strings>
       </Menu>
+
+      <Menu guid="TestExtension" id="RunnerWindowToolbar" type="ToolWindowToolbar">
+        <CommandFlag>DefaultDocked</CommandFlag>
+        <Strings>
+          <ButtonText>Runner Window Toolbar</ButtonText>
+        </Strings>
+      </Menu>
     </Menus>
 
     <Groups>
@@ -44,6 +51,10 @@
 
       <Group guid="TestExtension" id="TestExtensionEditProjectFileGroup" priority="0x1102">
         <Parent guid="TestExtension" id="TestExtensionEditProjectFileMenu" />
+      </Group>
+
+      <Group guid="TestExtension" id="RunnerWindowToolbarGroup" priority="0x0000">
+        <Parent guid="TestExtension" id="RunnerWindowToolbar" />
       </Group>
     </Groups>
 
@@ -97,6 +108,7 @@
         <Parent guid="TestExtension" id="TestExtensionMainMenuGroup1"/>
         <Icon guid="ImageCatalogGuid" id="BuildSolution" />
         <CommandFlag>IconIsMoniker</CommandFlag>
+        <CommandFlag>IconAndText</CommandFlag>
         <Strings>
           <ButtonText>Build Solution Async</ButtonText>
         </Strings>
@@ -124,7 +136,7 @@
           <ButtonText>Unload Selected Project</ButtonText>
         </Strings>
       </Button>
-      
+
       <Button guid="TestExtension" id="EditProjectFile" priority="0x0105" type="Button">
         <Parent guid="TestExtension" id="TestExtensionEditProjectFileGroup"/>
         <CommandFlag>DynamicItemStart</CommandFlag>
@@ -172,8 +184,28 @@
           <ButtonText>Collapse Selected Items</ButtonText>
         </Strings>
       </Button>
+
+      <Button guid="TestExtension" id="SendMessageToRunnerWindow" priority="0x0001">
+        <Parent guid="TestExtension" id="RunnerWindowToolbarGroup"/>
+        <Icon guid="ImageCatalogGuid" id="Send"/>
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <CommandFlag>IconAndText</CommandFlag>
+        <Strings>
+          <ButtonText>Send Message to Runner Window</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
   </Commands>
+
+  <CommandPlacements>
+    <!-- 
+    Put the "Build Solution Async" command on the Runner Window's toolbar 
+    as well (it also appears in the "VSSDK Test Extension" menu.
+    -->
+    <CommandPlacement guid="TestExtension" id="BuildSolutionAsync" priority="0x0000">
+      <Parent guid="TestExtension" id="RunnerWindowToolbarGroup"/>
+    </CommandPlacement>
+  </CommandPlacements>
 
   <VisibilityConstraints>
     <VisibilityItem guid="TestExtension" id="EditProjectFile" context="UICONTEXT_SolutionExists" />
@@ -188,6 +220,7 @@
       <IDSymbol name="TestExtensionMainMenuGroup1" value="0x1100" />
       <IDSymbol name="TestExtensionSolutionExplorerGroup" value="0x1101" />
       <IDSymbol name="TestExtensionEditProjectFileGroup" value="0x1102" />
+      <IDSymbol name="RunnerWindowToolbarGroup" value="0x1103" />
 
       <IDSymbol name="RunnerWindow" value="0x0100" />
       <IDSymbol name="ThemeWindow" value="0x0101" />
@@ -203,8 +236,11 @@
       <IDSymbol name="ListReferences" value="0x0111" />
       <IDSymbol name="LoadSelectedProject" value="0x0112" />
       <IDSymbol name="UnloadSelectedProject" value="0x0113" />
+      <IDSymbol name="SendMessageToRunnerWindow" value="0x0114" />
 
       <IDSymbol name="EditProjectFile" value="0x2001" />
+
+      <IDSymbol name="RunnerWindowToolbar" value="3000"/>
     </GuidSymbol>
   </Symbols>
 </CommandTable>

--- a/demo/VSSDK.TestExtension/VSSDK.TestExtension.csproj
+++ b/demo/VSSDK.TestExtension/VSSDK.TestExtension.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Commands\MultiInstanceWindowCommand.cs" />
     <Compile Include="Commands\EditSelectedItemLabelCommand.cs" />
     <Compile Include="Commands\SelectCurrentProjectCommand.cs" />
+    <Compile Include="Commands\SendMessageToRunnerWindowCommand.cs" />
     <Compile Include="Commands\ToggleVsixManifestFilterCommand.cs" />
     <Compile Include="Commands\RunnerWindowCommand.cs" />
     <Compile Include="Commands\ThemeWindowCommand.cs" />
@@ -72,6 +73,7 @@
     <Compile Include="ToolWindows\RunnerWindowControl.xaml.cs">
       <DependentUpon>RunnerWindowControl.xaml</DependentUpon>
     </Compile>
+    <Compile Include="ToolWindows\RunnerWindowMessenger.cs" />
     <Compile Include="ToolWindows\ThemeWindow\ThemedControl.cs" />
     <Compile Include="ToolWindows\ThemeWindow\ThemeWindow.cs" />
     <Compile Include="ToolWindows\ThemeWindow\ThemeWindowControl.xaml.cs">


### PR DESCRIPTION
This demonstrates how to add a toolbar to a tool window. 

Documentation for how to do this _without_ using the toolkit can be found here: https://docs.microsoft.com/en-us/visualstudio/extensibility/adding-a-toolbar-to-a-tool-window?view=vs-2022

Doing this _with_ the toolkit is basically the same. The toolbar is added by setting the `Toolbar` property on the internal `Pane` class of your tool window, because that's the class that inherits `ToolWindowPane`.

In this example, I've used a [`CommandPlacement`](https://docs.microsoft.com/en-us/visualstudio/extensibility/commandplacements-element?view=vs-2022) in the `.vsct` file to add the "Build Solution Async" command to the toolbar. The command also continues to appear in the "VSSDK Test Extension" menu. 

I've also added a new command to demonstrate one way that you can communicate between the toolbar and the tool window. As I've stressed in the comments, this should _not_ be considered a "best practice" or a "recommended" way to achieve that communication, but nor is it the wrong way. It's simply demonstrating that it is possible for a toolbar button to send messages to the tool window. 😄 

![image](https://user-images.githubusercontent.com/10321525/145567549-c86ab1ef-804d-48ea-b3c6-c611d43af246.png)
