### PR TITLE
Analyzer for adding ComVisibleAttribute to DialogPage

### DIFF
--- a/demo/VSSDK.TestExtension/Options/General.cs
+++ b/demo/VSSDK.TestExtension/Options/General.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Globalization;
 using Community.VisualStudio.Toolkit;
 using Microsoft.VisualStudio.Shell;
+using System.Runtime.InteropServices;
 
 namespace TestExtension
 {
@@ -12,6 +13,7 @@ namespace TestExtension
         // Register the options with these attributes in your package class:
         // [ProvideOptionPage(typeof(OptionsProvider.GeneralOptions), "My options", "General", 0, 0, true)]
         // [ProvideProfile(typeof(OptionsProvider.GeneralOptions), "My options", "General", 0, 0, true)]
+        [ComVisible(true)]
         public class GeneralOptions : BaseOptionPage<General> { }
     }
 

--- a/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Analyzers/CVST001CastInteropServicesAnalyzer.cs
+++ b/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Analyzers/CVST001CastInteropServicesAnalyzer.cs
@@ -26,7 +26,7 @@ namespace Community.VisualStudio.Toolkit.Analyzers
             isEnabledByDefault: true,
             description: GetLocalizableString(nameof(Resources.CVST001_Description)));
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(_rule); } }
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(_rule);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Analyzers/CVST001CastInteropServicesCodeFixProvider.cs
+++ b/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Analyzers/CVST001CastInteropServicesCodeFixProvider.cs
@@ -13,9 +13,9 @@ namespace Community.VisualStudio.Toolkit.Analyzers
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CVST001CastInteropServicesCodeFixProvider))]
     [Shared]
-    public class CVST001CastInteropServicesCodeFixProvider : CodeFixProvider
+    public class CVST001CastInteropServicesCodeFixProvider : CodeFixProviderBase
     {
-        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(CVST001CastInteropServicesAnalyzer.DiagnosticId);
+        public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(CVST001CastInteropServicesAnalyzer.DiagnosticId);
 
         public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
@@ -207,59 +207,6 @@ namespace Community.VisualStudio.Toolkit.Analyzers
 
             variableDeclaration = null!;
             return false;
-        }
-
-        private static SyntaxList<UsingDirectiveSyntax> AddUsingDirectiveIfMissing(SyntaxList<UsingDirectiveSyntax> usings, NameSyntax namespaceName)
-        {
-            string namespaceToImport = namespaceName.ToString();
-            int? insertionIndex = null;
-
-            // If the `using` directive is missing, then when we add it, we'll
-            // attempt to keep the existing statements in alphabetical order.
-            for (int i = 0; i < usings.Count; i++)
-            {
-                // Type aliases are usually put last, so if we haven't found an
-                // insertion index yet, then we can insert it before this statement.
-                if (usings[i].Alias is not null)
-                {
-                    if (!insertionIndex.HasValue)
-                    {
-                        insertionIndex = i;
-                    }
-                }
-                else
-                {
-                    string name = usings[i].Name.ToString();
-                    // If the namespace is already imported, then we can return
-                    // the original list of `using` directives without modifying them.
-                    if (string.Equals(name, namespaceToImport, System.StringComparison.Ordinal))
-                    {
-                        return usings;
-                    }
-
-                    // If we don't have an insertion index, and this `using` directive is
-                    // greater than the one we want to insert, then this is the first
-                    // directive that should appear after the one we insert.
-                    if (!insertionIndex.HasValue && string.Compare(name, namespaceToImport) > 0)
-                    {
-                        insertionIndex = i;
-                    }
-                }
-            }
-
-            UsingDirectiveSyntax directive = SyntaxFactory.UsingDirective(namespaceName);
-
-            // If we found where to insert the new directive, then insert
-            // it at that index; otherwise, it must be greater than all
-            // existing directives, so add it to the end of the list.
-            if (insertionIndex.HasValue)
-            {
-                return usings.Insert(insertionIndex.Value, directive);
-            }
-            else
-            {
-                return usings.Add(directive);
-            }
         }
     }
 }

--- a/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Analyzers/CVST002DialogPageShouldBeComVisibleAnalyzer.cs
+++ b/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Analyzers/CVST002DialogPageShouldBeComVisibleAnalyzer.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Community.VisualStudio.Toolkit.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class CVST002DialogPageShouldBeComVisibleAnalyzer : AnalyzerBase
+    {
+        internal const string DiagnosticId = Diagnostics.DialogPageShouldBeComVisible;
+
+        private static readonly DiagnosticDescriptor _rule = new(
+            DiagnosticId,
+            GetLocalizableString(nameof(Resources.CVST002_Title)),
+            GetLocalizableString(nameof(Resources.CVST002_MessageFormat)),
+            "Usage",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(_rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterCompilationStartAction(OnCompilationStart);
+        }
+
+        private void OnCompilationStart(CompilationStartAnalysisContext context)
+        {
+            INamedTypeSymbol? dialogPageType = context.Compilation.GetTypeByMetadataName("Microsoft.VisualStudio.Shell.DialogPage");
+            INamedTypeSymbol? comVisibleType = context.Compilation.GetTypeByMetadataName("System.Runtime.InteropServices.ComVisibleAttribute");
+
+            if (dialogPageType is not null && comVisibleType is not null)
+            {
+                context.RegisterSyntaxNodeAction((c) => AnalyzeClass(c, dialogPageType, comVisibleType), SyntaxKind.ClassDeclaration);
+            }
+        }
+
+        private static void AnalyzeClass(SyntaxNodeAnalysisContext context, INamedTypeSymbol dialogPageType, INamedTypeSymbol comVisibleType)
+        {
+            ClassDeclarationSyntax classDeclaration = (ClassDeclarationSyntax)context.Node;
+            ITypeSymbol? type = context.ContainingSymbol as ITypeSymbol;
+
+            if (type is not null && IsDialogPage(type, dialogPageType))
+            {
+                // This class inherits from `DialogPage`. It should contain
+                // a `ComVisible` attribute with a parameter of `true`.
+                foreach (AttributeData attribute in type.GetAttributes())
+                {
+                    if (attribute.AttributeClass.Equals(comVisibleType))
+                    {
+                        if (attribute.ConstructorArguments.Length == 1)
+                        {
+                            if (Equals(attribute.ConstructorArguments[0].Value, true))
+                            {
+                                return;
+                            }
+                        }
+                    }
+                }
+
+                // The `ComVisible` attribute was not found, so report the diagnostic.
+                context.ReportDiagnostic(Diagnostic.Create(_rule, classDeclaration.Identifier.GetLocation()));
+            }
+        }
+
+        private static bool IsDialogPage(ITypeSymbol? type, INamedTypeSymbol dialogPageType)
+        {
+            while (type is not null)
+            {
+                if (type.Equals(dialogPageType))
+                {
+                    return true;
+                }
+
+                type = type.BaseType;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Analyzers/CVST002DialogPageShouldBeComVisibleCodeFixProvider.cs
+++ b/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Analyzers/CVST002DialogPageShouldBeComVisibleCodeFixProvider.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Community.VisualStudio.Toolkit.Analyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CVST001CastInteropServicesCodeFixProvider))]
+    [Shared]
+    public class CVST002DialogPageShouldBeComVisibleCodeFixProvider : CodeFixProviderBase
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(CVST002DialogPageShouldBeComVisibleAnalyzer.DiagnosticId);
+
+        public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+            foreach (Diagnostic diagnostic in context.Diagnostics)
+            {
+                TextSpan span = diagnostic.Location.SourceSpan;
+                ClassDeclarationSyntax? classDeclaration = root.FindToken(span.Start).Parent as ClassDeclarationSyntax;
+
+                if (classDeclaration is not null)
+                {
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            Resources.CVST002_CodeFix,
+                            c => AddComVisibleAttributeAsync(context.Document, classDeclaration, c),
+                            equivalenceKey: nameof(Resources.CVST002_CodeFix)
+                        ),
+                        diagnostic
+                    );
+                }
+            }
+        }
+
+        private async Task<Document> AddComVisibleAttributeAsync(Document document, ClassDeclarationSyntax classDeclaration, CancellationToken cancellationToken)
+        {
+            SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken);
+            SyntaxEditor editor = new(root, document.Project.Solution.Workspace);
+            SyntaxGenerator generator = editor.Generator;
+
+            SyntaxNode attribute = generator.Attribute("ComVisible", new[] { generator.TrueLiteralExpression() });
+            editor.AddAttribute(classDeclaration, attribute);
+
+            root = editor.GetChangedRoot();
+
+            // Add a using directive for the namespace
+            // if the namespace is not already imported.
+            if (root is CompilationUnitSyntax unit)
+            {
+                root = unit.WithUsings(AddUsingDirectiveIfMissing(unit.Usings, SyntaxFactory.ParseName("System.Runtime.InteropServices")));
+            }
+
+            return document.WithSyntaxRoot(root);
+        }
+    }
+}

--- a/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/CodeFixProviderBase.cs
+++ b/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/CodeFixProviderBase.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Community.VisualStudio.Toolkit.Analyzers
+{
+    public abstract class CodeFixProviderBase : CodeFixProvider
+    {
+        protected static SyntaxList<UsingDirectiveSyntax> AddUsingDirectiveIfMissing(SyntaxList<UsingDirectiveSyntax> usings, NameSyntax namespaceName)
+        {
+            string namespaceToImport = namespaceName.ToString();
+            int? insertionIndex = null;
+
+            // If the `using` directive is missing, then when we add it, we'll
+            // attempt to keep the existing statements in alphabetical order.
+            for (int i = 0; i < usings.Count; i++)
+            {
+                // Type aliases are usually put last, so if we haven't found an
+                // insertion index yet, then we can insert it before this statement.
+                if (usings[i].Alias is not null)
+                {
+                    if (!insertionIndex.HasValue)
+                    {
+                        insertionIndex = i;
+                    }
+                }
+                else
+                {
+                    string name = usings[i].Name.ToString();
+                    // If the namespace is already imported, then we can return
+                    // the original list of `using` directives without modifying them.
+                    if (string.Equals(name, namespaceToImport, System.StringComparison.Ordinal))
+                    {
+                        return usings;
+                    }
+
+                    // If we don't have an insertion index, and this `using` directive is
+                    // greater than the one we want to insert, then this is the first
+                    // directive that should appear after the one we insert.
+                    if (!insertionIndex.HasValue && string.Compare(name, namespaceToImport) > 0)
+                    {
+                        insertionIndex = i;
+                    }
+                }
+            }
+
+            UsingDirectiveSyntax directive = SyntaxFactory.UsingDirective(namespaceName);
+
+            // If we found where to insert the new directive, then insert
+            // it at that index; otherwise, it must be greater than all
+            // existing directives, so add it to the end of the list.
+            if (insertionIndex.HasValue)
+            {
+                return usings.Insert(insertionIndex.Value, directive);
+            }
+            else
+            {
+                return usings.Add(directive);
+            }
+        }
+
+    }
+}

--- a/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Diagnostics.cs
+++ b/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Diagnostics.cs
@@ -3,5 +3,6 @@
     public static class Diagnostics
     {
         public const string CastInteropTypes = "CVST001";
+        public const string DialogPageShouldBeComVisible = "CVST002";
     }
 }

--- a/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Resources.Designer.cs
+++ b/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Resources.Designer.cs
@@ -96,5 +96,32 @@ namespace Community.VisualStudio.Toolkit.Analyzers {
                 return ResourceManager.GetString("CVST001_Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add [ComVisible(true)].
+        /// </summary>
+        internal static string CVST002_CodeFix {
+            get {
+                return ResourceManager.GetString("CVST002_CodeFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DialogPage implementations should be visible to COM.
+        /// </summary>
+        internal static string CVST002_MessageFormat {
+            get {
+                return ResourceManager.GetString("CVST002_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Make DialogPage implementations visible to COM.
+        /// </summary>
+        internal static string CVST002_Title {
+            get {
+                return ResourceManager.GetString("CVST002_Title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Resources.resx
+++ b/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Resources.resx
@@ -129,4 +129,13 @@
   <data name="CVST001_Title" xml:space="preserve">
     <value>Cast interop services to their specific type</value>
   </data>
+  <data name="CVST002_CodeFix" xml:space="preserve">
+    <value>Add [ComVisible(true)]</value>
+  </data>
+  <data name="CVST002_MessageFormat" xml:space="preserve">
+    <value>DialogPage implementations should be visible to COM</value>
+  </data>
+  <data name="CVST002_Title" xml:space="preserve">
+    <value>Make DialogPage implementations visible to COM</value>
+  </data>
 </root>

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Options/BaseOptionPage.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Options/BaseOptionPage.cs
@@ -1,11 +1,12 @@
-﻿using Microsoft.VisualStudio.Shell;
-using Task = System.Threading.Tasks.Task;
+﻿using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.Shell;
 
 namespace Community.VisualStudio.Toolkit
 {
     /// <summary>
     /// A base class for a DialogPage to show in Tools -> Options.
     /// </summary>
+    [ComVisible(true)]
     public class BaseOptionPage<T> : DialogPage where T : BaseOptionModel<T>, new()
     {
         private readonly BaseOptionModel<T> _model;

--- a/test/analyzers/Community.VisualStudio.Toolkit.Analyzers.UnitTests/Analyzers/CVST002DialogPageShouldBeComVisibleAnalyzerTests.cs
+++ b/test/analyzers/Community.VisualStudio.Toolkit.Analyzers.UnitTests/Analyzers/CVST002DialogPageShouldBeComVisibleAnalyzerTests.cs
@@ -1,0 +1,154 @@
+﻿using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Xunit;
+
+namespace Community.VisualStudio.Toolkit.Analyzers.UnitTests
+{
+    public class CVST002DialogPageShouldBeComVisibleAnalyzerTests : TestBase<CVST002DialogPageShouldBeComVisibleAnalyzer, CVST002DialogPageShouldBeComVisibleCodeFixProvider>
+    {
+        public CVST002DialogPageShouldBeComVisibleAnalyzerTests()
+        {
+            AddReference(typeof(DialogPage));
+            AddReference(typeof(ComVisibleAttribute));
+        }
+
+        [Fact]
+        public async Task DoesNotFlagDialogPageImplementationsThatAreAlreadyComVisibleAsync()
+        {
+            TestCode = @"
+using Microsoft.VisualStudio.Shell;
+using System.Runtime.InteropServices;
+
+[ComVisible(true)]
+class Foo : DialogPage {}
+";
+
+            await VerifyAsync();
+        }
+
+        [Fact]
+        public async Task DetectsMissingComVisibleAttributeAsync()
+        {
+            TestCode = @"
+using Microsoft.VisualStudio.Shell;
+
+class {|#0:Foo|} : DialogPage {}
+";
+
+            Expect(Diagnostic(Diagnostics.DialogPageShouldBeComVisible).WithLocation(0));
+
+            FixedCode = @"
+using Microsoft.VisualStudio.Shell;
+using System.Runtime.InteropServices;
+
+[ComVisible(true)]
+class Foo : DialogPage {}
+";
+
+            await VerifyAsync();
+        }
+
+        [Fact]
+        public async Task DetectsMissingComVisibleAttributeWhenClassIndirectlyInheritsDialogPageAsync()
+        {
+            TestCode = @"
+using Microsoft.VisualStudio.Shell;
+using System.Runtime.InteropServices;
+
+class {|#0:Foo|} : Bar {}
+
+[ComVisible(true)]
+class Bar : DialogPage {}
+";
+
+            Expect(Diagnostic(Diagnostics.DialogPageShouldBeComVisible).WithLocation(0));
+
+            FixedCode = @"
+using Microsoft.VisualStudio.Shell;
+using System.Runtime.InteropServices;
+
+[ComVisible(true)]
+class Foo : Bar {}
+
+[ComVisible(true)]
+class Bar : DialogPage {}
+";
+
+            await VerifyAsync();
+        }
+
+        [Fact]
+        public async Task CodeFixDoesNotImportNamespaceIfNamespaceIsAlreadyImportedAsync()
+        {
+            TestCode = @"
+using Microsoft.VisualStudio.Shell;
+using System.Runtime.InteropServices;
+
+class {|#0:Foo|} : DialogPage { }
+";
+
+            Expect(Diagnostic(Diagnostics.DialogPageShouldBeComVisible).WithLocation(0));
+
+            FixedCode = @"
+using Microsoft.VisualStudio.Shell;
+using System.Runtime.InteropServices;
+
+[ComVisible(true)]
+class Foo : DialogPage { }
+";
+
+            await VerifyAsync();
+        }
+
+        [Fact]
+        public async Task CodeFixCanAddAttributeWhenClassContainsOtherAttributesAsync()
+        {
+            TestCode = @"
+using Microsoft.VisualStudio.Shell;
+using System;
+
+[Serializable]
+class {|#0:Foo|} : DialogPage { }
+";
+
+            Expect(Diagnostic(Diagnostics.DialogPageShouldBeComVisible).WithLocation(0));
+
+            FixedCode = @"
+using Microsoft.VisualStudio.Shell;
+using System;
+using System.Runtime.InteropServices;
+
+[Serializable]
+[ComVisible(true)]
+class Foo : DialogPage { }
+";
+
+            await VerifyAsync();
+        }
+
+        [Fact]
+        public async Task CodeFixAddsTheAttributeAfterXmlDocumentationAsync()
+        {
+            TestCode = @"
+using Microsoft.VisualStudio.Shell;
+
+/// <summary>Test class.</summary>
+class {|#0:Foo|} : DialogPage { }
+";
+
+            Expect(Diagnostic(Diagnostics.DialogPageShouldBeComVisible).WithLocation(0));
+
+            FixedCode = @"
+using Microsoft.VisualStudio.Shell;
+using System.Runtime.InteropServices;
+
+/// <summary>Test class.</summary>
+[ComVisible(true)]
+class Foo : DialogPage { }
+";
+
+            await VerifyAsync();
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new code analyzer. This analyzer will detect classes that inherit from `DialogPage` that do not have the `[ComVisible(true)]` attribute. That attribute is required if the class `DialogPage` needs to support profiles (and there's no harm adding it if profiles don't need to be supported). Without it, exporting settings will silently ignore the settings defined in the `DialogPage`.