### PR TITLE
Hide code files that are included from the NuGet package

### DIFF
--- a/src/toolkit/nuget/build/Community.VisualStudio.Toolkit.props
+++ b/src/toolkit/nuget/build/Community.VisualStudio.Toolkit.props
@@ -9,7 +9,7 @@
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
 
-    <Compile Condition="'$(Language)'=='C#'" Include="$(MSBuildThisFileDirectory)*.cs" />
+    <Compile Condition="'$(Language)'=='C#'" Include="$(MSBuildThisFileDirectory)*.cs" Visible="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The toolkit includes an AssemblyInfo.cs file which ensures that the `ProvideCodeBase` attribute is applied to your extension. This file shows up in Solution Explorer, which is a bit confusing because it's not a file that you should edit.

![image](https://user-images.githubusercontent.com/10321525/147626653-4a049024-cf1e-442f-b342-141070f761de.png)


I've added `Visible=false` metadata to the `Compile` item so that the file doesn't appear in Solution Explorer but is still included in the compilation.

