### PR TITLE
Fixes an issue when trying to switch between projects for a shared file.

### DIFF
--- a/Community.VisualStudio.Toolkit.sln
+++ b/Community.VisualStudio.Toolkit.sln
@@ -79,10 +79,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "imports", "imports", "{544D
 		src\toolkit\nuget\build\imports\PublishToMarketplace.targets = src\toolkit\nuget\build\imports\PublishToMarketplace.targets
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MockVsixPublisher", "tools\MockVsixPublisher\MockVsixPublisher.csproj", "{C1BD4EBE-F43C-4A51-9801-A04E5C2C8B3E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MockVsixPublisher", "tools\MockVsixPublisher\MockVsixPublisher.csproj", "{C1BD4EBE-F43C-4A51-9801-A04E5C2C8B3E}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		src\toolkit\Community.VisualStudio.Toolkit.Shared\VSSDK.Helpers.Shared.projitems*{38dc82ea-91d6-4360-b76c-995708ee43a3}*SharedItemsImports = 5
+		src\toolkit\Community.VisualStudio.Toolkit.Shared\VSSDK.Helpers.Shared.projitems*{5ec463ac-24cb-443e-9ff9-91b7ecb1f822}*SharedItemsImports = 13
+		src\toolkit\Community.VisualStudio.Toolkit.Shared\VSSDK.Helpers.Shared.projitems*{86209d58-39b0-4d96-aa71-ff0d009e627a}*SharedItemsImports = 5
+		src\toolkit\Community.VisualStudio.Toolkit.Shared\VSSDK.Helpers.Shared.projitems*{a9e80c7b-8ed1-4d7b-b1f3-575fd70001ba}*SharedItemsImports = 5
+		src\toolkit\Community.VisualStudio.Toolkit.Shared\VSSDK.Helpers.Shared.projitems*{d000c76d-4d0f-48f9-b5ab-5696c92cc7bd}*SharedItemsImports = 5
 		src\toolkit\Community.VisualStudio.Toolkit.Shared\VSSDK.Helpers.Shared.projitems*{ff58bacd-16b0-4c73-ba03-4a255925153f}*SharedItemsImports = 5
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/toolkit/Community.VisualStudio.Toolkit.14.0/Community.VisualStudio.Toolkit.14.0.csproj
+++ b/src/toolkit/Community.VisualStudio.Toolkit.14.0/Community.VisualStudio.Toolkit.14.0.csproj
@@ -12,4 +12,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime" Version="12.1.30329" />
   </ItemGroup>
 
+  <Import Project="..\Community.VisualStudio.Toolkit.Shared\VSSDK.Helpers.Shared.projitems" Label="Shared" />
+
 </Project>

--- a/src/toolkit/Community.VisualStudio.Toolkit.15.0/Community.VisualStudio.Toolkit.15.0.csproj
+++ b/src/toolkit/Community.VisualStudio.Toolkit.15.0/Community.VisualStudio.Toolkit.15.0.csproj
@@ -11,4 +11,6 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
+  <Import Project="..\Community.VisualStudio.Toolkit.Shared\VSSDK.Helpers.Shared.projitems" Label="Shared" />
+  
 </Project>

--- a/src/toolkit/Community.VisualStudio.Toolkit.16.0/Community.VisualStudio.Toolkit.16.0.csproj
+++ b/src/toolkit/Community.VisualStudio.Toolkit.16.0/Community.VisualStudio.Toolkit.16.0.csproj
@@ -20,5 +20,7 @@
     -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" ReferenceOutputAssembly="false" PrivateAssets="All" />
   </ItemGroup>
+
+  <Import Project="..\Community.VisualStudio.Toolkit.Shared\VSSDK.Helpers.Shared.projitems" Label="Shared" />
   
 </Project>

--- a/src/toolkit/Community.VisualStudio.Toolkit.17.0/Community.VisualStudio.Toolkit.17.0.csproj
+++ b/src/toolkit/Community.VisualStudio.Toolkit.17.0/Community.VisualStudio.Toolkit.17.0.csproj
@@ -21,4 +21,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.0-6.final" ReferenceOutputAssembly="false" PrivateAssets="All" />
   </ItemGroup>
 
+  <Import Project="..\Community.VisualStudio.Toolkit.Shared\VSSDK.Helpers.Shared.projitems" Label="Shared" />
+
 </Project>

--- a/src/toolkit/Directory.Build.props
+++ b/src/toolkit/Directory.Build.props
@@ -49,7 +49,5 @@
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\analyzers\Community.VisualStudio.Toolkit.Analyzers\Community.VisualStudio.Toolkit.Analyzers.csproj"/>
   </ItemGroup>
-  
-  <Import Project="$(MSBuildThisFileDirectory)Community.VisualStudio.Toolkit.Shared\VSSDK.Helpers.Shared.projitems" Label="Shared" />
 
 </Project>


### PR DESCRIPTION
There has been an issue with regards to using the project dropdown when working with files from the shared project:
![image](https://user-images.githubusercontent.com/11198735/153311399-f9d8b33b-f01a-4686-af57-83f3b85951dc.png)

It appears that we are unable to `Import` the shared project using a `.props` file. Each project must reference the shared project individually.

You can see the issue reported to MS [here](https://developercommunity.visualstudio.com/t/systemargumentoutofrangeexception-specified-argume-2/1427702?from=email&viewtype=all#T-N1654857).