### PR TITLE
Cancel project build if any project is canceled

### DIFF
--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Build/Build.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Build/Build.cs
@@ -169,18 +169,16 @@ namespace Community.VisualStudio.Toolkit
             {
                 if (_hierarchy is not null)
                 {
+                    if (fCancel != 0)
+                    {
+                        _result.SetCanceled();
+                    }
+
                     // We are observing the build of a specific project. If the project
                     // that finished is the one we are observing, then we can set the result.
                     if (pHierProj == _hierarchy)
                     {
-                        if (fCancel != 0)
-                        {
-                            _result.SetCanceled();
-                        }
-                        else
-                        {
-                            _result.SetResult(fSuccess != 0);
-                        }
+                        _result.SetResult(fSuccess != 0);
                     }
                 }
 


### PR DESCRIPTION
If a project being built has the build canceled while building a project it is dependent on, the result never gets set. This pull request changes the code to cancel the result if any project is canceled. I think this is a safe assumption to make?

You can re-create this issue with the BuildActiveProjectAsyncCommand in the test extension. Build a project that is dependent on one or more projects and cancel the build before it gets to the active project. The build will be canceled, but you will not see any of the message boxes.