### PR TITLE
Update Project.BuildAsync() to return success flag

### DIFF
--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Solution/Project.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Solution/Project.cs
@@ -23,7 +23,7 @@ namespace Community.VisualStudio.Toolkit
         /// <summary>
         /// Starts a build, rebuild, or clean of the project.
         /// </summary>
-        public Task BuildAsync(BuildAction action = BuildAction.Build)
+        public Task<bool> BuildAsync(BuildAction action = BuildAction.Build)
         {
             return VS.Build.BuildProjectAsync(this, action);
         }


### PR DESCRIPTION
This pull request updates Project.BuildAsync() to return the success flag from VS.Build.BuildProjectAsync().