### PR TITLE
Fix exception being thrown when the project being observed is the one…

### DIFF
--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Build/Build.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Build/Build.cs
@@ -173,10 +173,9 @@ namespace Community.VisualStudio.Toolkit
                     {
                         _result.SetCanceled();
                     }
-
                     // We are observing the build of a specific project. If the project
                     // that finished is the one we are observing, then we can set the result.
-                    if (pHierProj == _hierarchy)
+                    else if (pHierProj == _hierarchy)
                     {
                         _result.SetResult(fSuccess != 0);
                     }


### PR DESCRIPTION
… canceled

My bad. I introduced a bug with 6e89e36208224b6c5f59d5ff6b784faf4bf0bd6d where an InvalidOperationException gets thrown when the project being observed is the one that is canceled since the result will be set twice. This fix ensures it will only be set once.