### PR TITLE
Allow styles to be extended

### DIFF
--- a/demo/VSSDK.TestExtension/ToolWindows/ThemeWindow/CustomizedStylesDialog.xaml
+++ b/demo/VSSDK.TestExtension/ToolWindows/ThemeWindow/CustomizedStylesDialog.xaml
@@ -1,0 +1,61 @@
+﻿<platform:DialogWindow 
+    x:Class="TestExtension.CustomizedStylesDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+    xmlns:platform="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+    xmlns:toolkit="clr-namespace:Community.VisualStudio.Toolkit;assembly=Community.VisualStudio.Toolkit"
+    xmlns:shell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
+    mc:Ignorable="d" 
+    d:DesignHeight="450" 
+    d:DesignWidth="800"
+    toolkit:Themes.UseVsTheme="True"
+    Width="300"
+    Height="400"
+    Title="Customized Styles"
+    WindowStartupLocation="CenterOwner"
+    ShowInTaskbar="False"
+    >
+
+    <Window.Resources>
+        <ResourceDictionary>
+            <!-- 
+            To customize a style provided by the toolkit, you need to make the resources 
+            available by including the resource dictionary from the toolkit:
+            -->
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="{x:Static toolkit:ToolkitResourceKeys.ThemeResourcesUri}"/>
+            </ResourceDictionary.MergedDictionaries>
+
+            <!--
+            Now you can create your own styles that are based on the toolkit's styles.
+            -->
+            <Style TargetType="TextBox" BasedOn="{StaticResource {x:Static toolkit:ToolkitResourceKeys.TextBoxStyleKey}}">
+                <Setter Property="BorderBrush" Value="Red" />
+            </Style>
+
+            <!--
+            The toolkit only defines a few customized styles. Most styles come from the default Visual Studio
+            styles. These can be referenced using the keys from `Microsoft.VisualStudio.Shell.VsResourceKeys`.
+            -->
+            <Style TargetType="Button" BasedOn="{StaticResource {x:Static shell:VsResourceKeys.ThemedDialogButtonStyleKey}}">
+                <Setter Property="Foreground" Value="Green" />
+            </Style>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <StackPanel Orientation="Vertical" Margin="10">
+        <TextBox 
+            Text="This TextBox uses the style from the toolkit, but extends it to have a red border."
+            AcceptsReturn="True"
+            Height="50"
+            TextWrapping="Wrap"
+            />
+
+        <Button
+            Content="Green text on a button"
+            Margin="0,10,0,0"
+            />
+    </StackPanel>
+</platform:DialogWindow>

--- a/demo/VSSDK.TestExtension/ToolWindows/ThemeWindow/CustomizedStylesDialog.xaml.cs
+++ b/demo/VSSDK.TestExtension/ToolWindows/ThemeWindow/CustomizedStylesDialog.xaml.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.VisualStudio.PlatformUI;
+
+namespace TestExtension
+{
+    public partial class CustomizedStylesDialog : DialogWindow
+    {
+        public CustomizedStylesDialog()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/demo/VSSDK.TestExtension/ToolWindows/ThemeWindow/ThemeWindowControl.xaml
+++ b/demo/VSSDK.TestExtension/ToolWindows/ThemeWindow/ThemeWindowControl.xaml
@@ -24,6 +24,7 @@
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
             <StackPanel 
@@ -55,6 +56,14 @@
                 Grid.Column="2"
                 Content="Open Dialog" 
                 Command="{Binding OpenDialogCommand}" 
+                VerticalAlignment="Center"
+                Margin="10,0"
+                />
+
+            <Button 
+                Grid.Column="3"
+                Content="Customized Styles" 
+                Command="{Binding OpenCustomStylesCommand}" 
                 VerticalAlignment="Center"
                 />
         </Grid>

--- a/demo/VSSDK.TestExtension/ToolWindows/ThemeWindow/ThemeWindowControlViewModel.cs
+++ b/demo/VSSDK.TestExtension/ToolWindows/ThemeWindow/ThemeWindowControlViewModel.cs
@@ -64,11 +64,18 @@ namespace TestExtension
 
 #pragma warning disable VSTHRD012 // Provide JoinableTaskFactory where allowed
         public ICommand OpenDialogCommand => new DelegateCommand(() => OpenDialog());
+        public ICommand OpenCustomStylesCommand => new DelegateCommand(() => OpenCustomStyles());
 #pragma warning restore VSTHRD012 // Provide JoinableTaskFactory where allowed
 
         private void OpenDialog()
         {
             ThemeWindowDialog dialog = new ThemeWindowDialog { DataContext = new ThemeWindowDialogViewModel { UseVsTheme = UseVsTheme } };
+            dialog.ShowModal();
+        }
+
+        private void OpenCustomStyles()
+        {
+            CustomizedStylesDialog dialog = new CustomizedStylesDialog();
             dialog.ShowModal();
         }
 

--- a/demo/VSSDK.TestExtension/VSSDK.TestExtension.csproj
+++ b/demo/VSSDK.TestExtension/VSSDK.TestExtension.csproj
@@ -79,6 +79,9 @@
       <DependentUpon>RunnerWindowControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="ToolWindows\RunnerWindowMessenger.cs" />
+    <Compile Include="ToolWindows\ThemeWindow\CustomizedStylesDialog.xaml.cs">
+      <DependentUpon>CustomizedStylesDialog.xaml</DependentUpon>
+    </Compile>
     <Compile Include="ToolWindows\ThemeWindow\ThemedControl.cs" />
     <Compile Include="ToolWindows\ThemeWindow\ThemeWindow.cs" />
     <Compile Include="ToolWindows\ThemeWindow\ThemeWindowControl.xaml.cs">
@@ -138,6 +141,10 @@
   </ItemGroup>
   <ItemGroup>
     <Page Include="Themes\Generic.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="ToolWindows\ThemeWindow\CustomizedStylesDialog.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Themes/InternalResourceKeys.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Themes/InternalResourceKeys.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Shell;
+
+namespace Community.VisualStudio.Toolkit
+{
+    /// <summary>
+    /// Re-defines resource keys and other properties used in XAML files, where the assembly that 
+    /// they are originally defined in has a different name depending on the version of the toolkit.
+    /// </summary>
+    internal static class InternalResourceKeys
+    {
+        // Defined in "clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.xx.0"
+        public static object VsResourceKeys_TextBoxStyleKey => VsResourceKeys.TextBoxStyleKey;
+        public static object VsResourceKeys_ComboBoxStyleKey => VsResourceKeys.ComboBoxStyleKey;
+
+        // Defined in "clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.xx.0"
+        public static object CommonControlsColors_TextBoxBackgroundBrushKey => CommonControlsColors.TextBoxBackgroundBrushKey;
+        public static object CommonControlsColors_TextBoxTextBrushKey => CommonControlsColors.TextBoxTextBrushKey;
+        public static object CommonControlsColors_TextBoxBorderBrushKey => CommonControlsColors.TextBoxBorderBrushKey;
+        public static object CommonControlsColors_TextBoxBackgroundFocusedBrushKey => CommonControlsColors.TextBoxBackgroundFocusedBrushKey;
+        public static object CommonControlsColors_TextBoxTextFocusedBrushKey => CommonControlsColors.TextBoxTextFocusedBrushKey;
+        public static object CommonControlsColors_TextBoxBorderFocusedBrushKey => CommonControlsColors.TextBoxBorderFocusedBrushKey;
+        public static object CommonControlsColors_TextBoxBackgroundDisabledBrushKey => CommonControlsColors.TextBoxBackgroundDisabledBrushKey;
+        public static object CommonControlsColors_TextBoxTextDisabledBrushKey => CommonControlsColors.TextBoxTextDisabledBrushKey;
+        public static object CommonControlsColors_TextBoxBorderDisabledBrushKey => CommonControlsColors.TextBoxBorderDisabledBrushKey;
+    }
+}

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Themes/ThemeResources.xaml
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Themes/ThemeResources.xaml
@@ -1,71 +1,72 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="clr-namespace:Community.VisualStudio.Toolkit;assembly=Community.VisualStudio.Toolkit"
-    xmlns:shell="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.15.0"
-    xmlns:platform="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+    xmlns:local="clr-namespace:Community.VisualStudio.Toolkit"
     xmlns:system="clr-namespace:System;assembly=mscorlib"
     >
 
     <!-- This is the same padding used by WatermarkedTextBox. -->
     <Thickness x:Key="{x:Static local:ToolkitResourceKeys.InputPaddingKey}">6,8,6,8</Thickness>
-    
+
     <!-- This is the same height used in the IVsThreadedWaitDialog. -->
     <system:Double x:Key="{x:Static local:ToolkitResourceKeys.ThickProgressBarHeight}">16</system:Double>
 
-    <Style TargetType="TextBox" BasedOn="{StaticResource {x:Static shell:VsResourceKeys.TextBoxStyleKey}}">
+    <Style x:Key="{x:Static local:ToolkitResourceKeys.TextBoxStyleKey}" TargetType="TextBox" BasedOn="{StaticResource {x:Static local:InternalResourceKeys.VsResourceKeys_TextBoxStyleKey}}">
         <Setter Property="Padding" Value="{StaticResource {x:Static local:ToolkitResourceKeys.InputPaddingKey}}" />
     </Style>
 
-    <Style TargetType="ComboBox" BasedOn="{StaticResource {x:Static shell:VsResourceKeys.ComboBoxStyleKey}}">
+    <Style x:Key="{x:Static local:ToolkitResourceKeys.ComboBoxStyleKey}" TargetType="ComboBox" BasedOn="{StaticResource {x:Static local:InternalResourceKeys.VsResourceKeys_ComboBoxStyleKey}}">
         <Setter Property="Padding" Value="{StaticResource {x:Static local:ToolkitResourceKeys.InputPaddingKey}}" />
     </Style>
 
-    <Style TargetType="PasswordBox">
+    <ControlTemplate x:Key="{x:Static local:ToolkitResourceKeys.PasswordBoxControlTemplateKey}" TargetType="{x:Type PasswordBox}">
+        <!-- 
+        The default template for a PasswordBox defines a trigger for IsMouseOver that changes the 
+        border brush. To get our style triggers to apply, we need to override the template.
+        -->
+        <Border
+            x:Name="border"
+            BorderBrush="{TemplateBinding BorderBrush}"
+            BorderThickness="{TemplateBinding BorderThickness}"
+            Background="{TemplateBinding Background}"
+            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+            >
+
+            <ScrollViewer x:Name="PART_ContentHost" Focusable="false" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden"/>
+        </Border>
+    </ControlTemplate>
+
+    <Style x:Key="{x:Static local:ToolkitResourceKeys.PasswordBoxStyleKey}" TargetType="PasswordBox">
         <Setter Property="Padding" Value="{StaticResource {x:Static local:ToolkitResourceKeys.InputPaddingKey}}" />
-        <Setter Property="Background" Value="{DynamicResource {x:Static platform:CommonControlsColors.TextBoxBackgroundBrushKey}}" />
-        <Setter Property="Foreground" Value="{DynamicResource {x:Static platform:CommonControlsColors.TextBoxTextBrushKey}}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static platform:CommonControlsColors.TextBoxBorderBrushKey}}" />
+        <Setter Property="Background" Value="{DynamicResource {x:Static local:InternalResourceKeys.CommonControlsColors_TextBoxBackgroundBrushKey}}" />
+        <Setter Property="Foreground" Value="{DynamicResource {x:Static local:InternalResourceKeys.CommonControlsColors_TextBoxTextBrushKey}}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static local:InternalResourceKeys.CommonControlsColors_TextBoxBorderBrushKey}}" />
 
-        <Setter Property="Template">
-            <Setter.Value>
-                <!-- 
-                The default template defines a trigger for IsMouseOver that changes the border
-                brush. To get our style triggers to apply, we need to override the template.
-                -->
-                <ControlTemplate TargetType="{x:Type PasswordBox}">
-                    <Border 
-                        x:Name="border" 
-                        BorderBrush="{TemplateBinding BorderBrush}" 
-                        BorderThickness="{TemplateBinding BorderThickness}" 
-                        Background="{TemplateBinding Background}" 
-                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                        >
-
-                        <ScrollViewer x:Name="PART_ContentHost" Focusable="false" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden"/>
-                    </Border>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-
+        <Setter Property="Template" Value="{StaticResource {x:Static local:ToolkitResourceKeys.PasswordBoxControlTemplateKey}}"/>
+        
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="Background" Value="{DynamicResource {x:Static platform:CommonControlsColors.TextBoxBackgroundBrushKey}}" />
-                <Setter Property="Foreground" Value="{DynamicResource {x:Static platform:CommonControlsColors.TextBoxTextBrushKey}}" />
-                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static platform:CommonControlsColors.TextBoxBorderBrushKey}}" />
+                <Setter Property="Background" Value="{DynamicResource {x:Static local:InternalResourceKeys.CommonControlsColors_TextBoxBackgroundBrushKey}}" />
+                <Setter Property="Foreground" Value="{DynamicResource {x:Static local:InternalResourceKeys.CommonControlsColors_TextBoxTextBrushKey}}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static local:InternalResourceKeys.CommonControlsColors_TextBoxBorderBrushKey}}" />
             </Trigger>
 
             <Trigger Property="IsFocused" Value="True">
-                <Setter Property="Background" Value="{DynamicResource {x:Static platform:CommonControlsColors.TextBoxBackgroundFocusedBrushKey}}" />
-                <Setter Property="Foreground" Value="{DynamicResource {x:Static platform:CommonControlsColors.TextBoxTextFocusedBrushKey}}" />
-                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static platform:CommonControlsColors.TextBoxBorderFocusedBrushKey}}" />
+                <Setter Property="Background" Value="{DynamicResource {x:Static local:InternalResourceKeys.CommonControlsColors_TextBoxBackgroundFocusedBrushKey}}" />
+                <Setter Property="Foreground" Value="{DynamicResource {x:Static local:InternalResourceKeys.CommonControlsColors_TextBoxTextFocusedBrushKey}}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static local:InternalResourceKeys.CommonControlsColors_TextBoxBorderFocusedBrushKey}}" />
             </Trigger>
 
             <Trigger Property="IsEnabled" Value="False">
-                <Setter Property="Background" Value="{DynamicResource {x:Static platform:CommonControlsColors.TextBoxBackgroundDisabledBrushKey}}" />
-                <Setter Property="Foreground" Value="{DynamicResource {x:Static platform:CommonControlsColors.TextBoxTextDisabledBrushKey}}" />
-                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static platform:CommonControlsColors.TextBoxBorderDisabledBrushKey}}" />
+                <Setter Property="Background" Value="{DynamicResource {x:Static local:InternalResourceKeys.CommonControlsColors_TextBoxBackgroundDisabledBrushKey}}" />
+                <Setter Property="Foreground" Value="{DynamicResource {x:Static local:InternalResourceKeys.CommonControlsColors_TextBoxTextDisabledBrushKey}}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static local:InternalResourceKeys.CommonControlsColors_TextBoxBorderDisabledBrushKey}}" />
             </Trigger>
         </Style.Triggers>
     </Style>
+
+    <!-- Default styles. -->
+    <Style TargetType="TextBox" BasedOn="{StaticResource {x:Static local:ToolkitResourceKeys.TextBoxStyleKey}}" />
+    <Style TargetType="ComboBox" BasedOn="{StaticResource {x:Static local:ToolkitResourceKeys.ComboBoxStyleKey}}" />
+    <Style TargetType="PasswordBox" BasedOn="{StaticResource {x:Static local:ToolkitResourceKeys.PasswordBoxStyleKey}}" />
 </ResourceDictionary>

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Themes/ToolkitResourceKeys.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Themes/ToolkitResourceKeys.cs
@@ -1,4 +1,7 @@
-﻿using System.Windows;
+﻿using System;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Controls;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Community.VisualStudio.Toolkit
@@ -8,6 +11,21 @@ namespace Community.VisualStudio.Toolkit
     {
         private const string _prefix = "Toolkit";
 
+        /// <summary>
+        /// Gets the URI of the <see cref="ResourceDictionary"/> that contains the theme resources.
+        /// </summary>
+        /// <remarks>
+        /// This can be used to load the <see cref="ResourceDictionary"/> when you would like to customize the styles.
+        /// <code>
+        /// &lt;ResourceDictionary&gt;
+        ///     &lt;ResourceDictionary.MergedDictionaries&gt;
+        ///         &lt;ResourceDictionary Source="{x:Static toolkit:ToolkitResourceKeys.ThemeResourcesUri}"/&gt;
+        ///     &lt;/ResourceDictionary.MergedDictionaries&gt;
+        /// &lt;/ResourceDictionary&gt;
+        /// </code>
+        /// </remarks>
+        public static Uri ThemeResourcesUri { get; } = BuildPackUri("Themes/ThemeResources.xaml");
+
         /// <summary>Gets the key that can be used to get the <see cref="Thickness"/> to use for input controls.</summary>
         public static object InputPaddingKey { get; } = _prefix + nameof(InputPaddingKey);
 
@@ -16,5 +34,27 @@ namespace Community.VisualStudio.Toolkit
         /// (similar to the height used in the <see cref="IVsThreadedWaitDialog"/>).
         /// </summary>
         public static object ThickProgressBarHeight { get; } = _prefix + nameof(ThickProgressBarHeight);
+
+        /// <summary>Gets the key that defines the resource for a Visual Studio-themed <see cref="TextBox"/> style.</summary>
+        public static object TextBoxStyleKey { get; } = _prefix + nameof(TextBoxStyleKey);
+
+        /// <summary>Gets the key that defines the resource for a Visual Studio-themed <see cref="ComboBox"/> style.</summary>
+        public static object ComboBoxStyleKey { get; } = _prefix + nameof(ComboBoxStyleKey);
+
+        /// <summary>Gets the key that defines the resource for a Visual Studio-themed <see cref="PasswordBox"/> style.</summary>
+        public static object PasswordBoxStyleKey { get; } = _prefix + nameof(PasswordBoxStyleKey);
+
+        /// <summary>Gets the key that defines the resource for the <see cref="ControlTemplate"/> of a Visual Studio-themed <see cref="PasswordBox"/> style.</summary>
+        public static object PasswordBoxControlTemplateKey { get; } = _prefix + nameof(PasswordBoxControlTemplateKey);
+
+        private static Uri BuildPackUri(string resource)
+        {
+            // Multiple versions of the toolkti assembly might be loaded, so when
+            // loading a resource, we need to include the version number of this
+            // assembly to ensure that the resource is loaded from the correct assembly.
+            AssemblyName assemblyName = typeof(ToolkitResourceKeys).Assembly.GetName();
+            string version = assemblyName.Version.ToString();
+            return new Uri($"pack://application:,,,/{assemblyName.Name};v{version};component/{resource}");
+        }
     }
 }

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
@@ -96,6 +96,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Solution\SolutionItemType.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Solution\Solutions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Solution\VirtualFolder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Themes\InternalResourceKeys.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Themes\Themes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Themes\ToolkitResourceKeys.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ToolkitPackage.cs" />

--- a/src/toolkit/Directory.Build.props
+++ b/src/toolkit/Directory.Build.props
@@ -30,12 +30,11 @@
     <!-- 
     Include the XAML theme resources file here rather than in the shared project, because 
     when it's included in the shared project, you don't get Intellisense when editing the file.
-    Also note that this is an EmbeddedResource rather than a Page, because we need to load and edit
-    the file at runtime to account for different assembly versions that are referenced in the namespaces.
     -->
-    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Community.VisualStudio.Toolkit.Shared\Themes\ThemeResources.xaml" Link="Themes\ThemeResources.xaml">
+    <Page Include="$(MSBuildThisFileDirectory)Community.VisualStudio.Toolkit.Shared\Themes\ThemeResources.xaml" Link="Themes\ThemeResources.xaml">
+      <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
-    </EmbeddedResource>
+    </Page>
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Fixed #135.

You can now extend the custom Visual Studio-themed styles. This required a few changes:

First, the resource dictionary needed to be compiled like any other XAML file by including it as a `Page`.

Doing that meant the `xmlns` attributes for the `Microsoft.VisualStudio.Shell.15.0` assembly could no longer be used. This is because in the v14 version of the toolkit, that assembly doesn't exist, and is actually `Microsoft.VisualStudio.Shell.14.0`. We were previously working around that by loading the XAML file from the embedded resources, doing some string replacement, and then parsing the file as a XAML file. I've solved this problem be creating an internal class called `InternalResourceKeys` in which we effectively alias the properties from `Microsoft.VisualStudio.Shell.xx.0` that we need to use. 

For example, `VsResourceKeys.TextBoxStyleKey` defines the key of the style for the `TextBox` control that we extend in `ThemeResources.xaml` (previously accessed as `shell:VsResourceKeys.TextBoxStyleKey`). The `InternalResourceKeys` class has a property called `VsResourceKeys_TextBoxStyleKey` which simply returns the value of `VsResourceKeys.TextBoxStyleKey`, and in `ThemeResources.xaml` we now use `local:VsResourceKeys_TextBoxStyleKey`.

I've also added `CustomizedStylesDialog` to the demo extension to demonstrate how the styles can be extended. There are two examples:
* One extends the toolkit's `TextBox` style.
* The other extends Visual Studio's `Button` style.

You can access that dialog via the _Theme Window_ tool window.