### PR TITLE
Set UseWPF build property to true for the toolkit projects.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,4 +8,8 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
+  <ItemGroup>
+    <SourceRoot Include="$(MSBuildThisFileDirectory)/"/>
+  </ItemGroup>
+
 </Project>

--- a/src/toolkit/Directory.Build.props
+++ b/src/toolkit/Directory.Build.props
@@ -10,6 +10,9 @@
     <RootNamespace>Community.VisualStudio.Toolkit</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DebugType>portable</DebugType>
+
+    <!-- Set UseWPF to true so that the XAML resources are compiled and included in the assembly. -->
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Fixes #322 

We needed to set the `UseWPF` build property to true.

> The UseWPF property controls whether or not to include references to WPF libraries. **This also alters the MSBuild pipeline to correctly process a WPF project and related files.**

https://docs.microsoft.com/en-US/dotnet/core/project-sdk/msbuild-props-desktop#usewpf