### PR TITLE
Ensured that only one "References" output pane is created by demo extension

### DIFF
--- a/demo/VSSDK.TestExtension/Commands/ListReferencesCommand.cs
+++ b/demo/VSSDK.TestExtension/Commands/ListReferencesCommand.cs
@@ -8,29 +8,35 @@ namespace TestExtension.Commands
     [Command(PackageIds.ListReferences)]
     internal sealed class ListReferencesCommand : BaseCommand<ListReferencesCommand>
     {
+        OutputWindowPane _pane;
+
         protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            OutputWindowPane pane = await VS.Windows.CreateOutputWindowPaneAsync("References");
-            await pane.ActivateAsync();
+            if (_pane is null)
+            {
+                _pane = await VS.Windows.CreateOutputWindowPaneAsync("References");
+            }
+
+            await _pane.ActivateAsync();
 
             foreach (Project project in await VS.Solutions.GetAllProjectsAsync())
             {
-                await pane.WriteLineAsync(project.Name);
+                await _pane.WriteLineAsync(project.Name);
                 foreach (Reference reference in project.References.OrderBy(x => x.Name))
                 {
                     if (reference is AssemblyReference assemblyRef)
                     {
-                        await pane.WriteLineAsync($"  * {reference.Name} (Assembly: {assemblyRef.FullPath})");
+                        await _pane.WriteLineAsync($"  * {reference.Name} (Assembly: {assemblyRef.FullPath})");
                     }
                     else if (reference is ProjectReference projectRef)
                     {
-                        await pane.WriteLineAsync($"  * {reference.Name} (Project: {(await projectRef.GetProjectAsync())?.Name ?? "?"})");
+                        await _pane.WriteLineAsync($"  * {reference.Name} (Project: {(await projectRef.GetProjectAsync())?.Name ?? "?"})");
                     }
                     else
                     {
-                        await pane.WriteLineAsync($"  * {reference.Name} (Unknown)");
+                        await _pane.WriteLineAsync($"  * {reference.Name} (Unknown)");
                     }
                 }
             }


### PR DESCRIPTION
The command was creating a new output pane each time it was run. Now it only creates a single output pane.