### PR TITLE
Fix WindowFrame.GetDocumentViewAsync() COMException due to documents pending initialization

### DIFF
--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Windows/WindowFrame.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Windows/WindowFrame.cs
@@ -231,6 +231,10 @@ namespace Community.VisualStudio.Toolkit
         /// <returns><see langword="null"/> if the window isn't a document window.</returns>
         public async Task<DocumentView?> GetDocumentViewAsync()
         {
+            // Force the loading of a document that may be pending initialization.
+            // See https://docs.microsoft.com/en-us/visualstudio/extensibility/internals/delayed-document-loading
+            _frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out _);
+
             IVsTextView? nativeView = VsShellUtilities.GetTextView(_frame);
 
             if (nativeView != null)


### PR DESCRIPTION
I've found that calling `WindowFrame.GetDocumentViewAsync()` can result in the line `IVsTextView? nativeView = VsShellUtilities.GetTextView(_frame);` throwing this exception:

```
System.Runtime.InteropServices.COMException (0x80004005): Error HRESULT E_FAIL has been returned from a call to a COM component.
   at System.Runtime.InteropServices.Marshal.ThrowExceptionForHRInternal(Int32 errorCode, IntPtr errorInfo)
   at Microsoft.VisualStudio.Shell.VsShellUtilities.GetTextView(IVsWindowFrame windowFrame)
   at Community.VisualStudio.Toolkit.WindowFrame.<GetDocumentViewAsync>d__37.MoveNext()
```

To trigger this exception, load Visual Studio with multiple documents open. Without changing the active document, call `GetDocumentViewAsync()` on one of the background documents. You can easily trigger it with this:
```
foreach (WindowFrame documentWindow in await VS.Windows.GetAllDocumentWindowsAsync())
{
    DocumentView documentView = await documentWindow.GetDocumentViewAsync();
}
```

My research brought me to this documentation: https://docs.microsoft.com/en-us/visualstudio/extensibility/internals/delayed-document-loading?view=vs-2022

This exception seems to occur because the document is pending initialization. To fix it, I'm forcing the document to load. I think it's a safe assumption that if someone is calling this method that they want to document to load. Alternatively, we could check if `__VSFPROPID6.VSFPROPID_PendingInitialization` is true and return null, but that seems like it would mislead people into thinking the frame isn't a document. We could also instead have the method take in an optional flag to force this initialization.