### PR TITLE
Allowed a tool window or its content to get access to the ToolWindowPane

### DIFF
--- a/demo/VSSDK.TestExtension/ToolWindows/RunnerWindow.cs
+++ b/demo/VSSDK.TestExtension/ToolWindows/RunnerWindow.cs
@@ -24,7 +24,7 @@ namespace TestExtension
         }
 
         [Guid("d3b3ebd9-87d1-41cd-bf84-268d88953417")]
-        internal class Pane : ToolWindowPane
+        internal class Pane : ToolkitToolWindowPane
         {
             public Pane()
             {

--- a/demo/VSSDK.TestExtension/ToolWindows/RunnerWindowControl.xaml.cs
+++ b/demo/VSSDK.TestExtension/ToolWindows/RunnerWindowControl.xaml.cs
@@ -5,11 +5,12 @@ using System.Windows.Controls;
 using Community.VisualStudio.Toolkit;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Task = System.Threading.Tasks.Task;
 
 namespace TestExtension
 {
-    public partial class RunnerWindowControl : UserControl
+    public partial class RunnerWindowControl : UserControl, IToolWindowPaneAware
     {
         public RunnerWindowControl(Version vsVersion, RunnerWindowMessenger messenger)
         {
@@ -54,6 +55,11 @@ namespace TestExtension
         private async Task HideAsync()
         {
             await RunnerWindow.HideAsync();
+        }
+
+        public void SetPane(ToolWindowPane pane)
+        {
+            MessageList.Items.Add("Pane has been set.");
         }
     }
 }

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
@@ -10,6 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Debugger\Debugger.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows\IToolWindowPaneAware.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows\ToolkitToolWindowPane.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Attributes\ProvideBraceCompletionAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Attributes\ProvideFileIconAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Attributes\ProvideGalleryFeedAttribute.cs" />

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Windows/BaseToolWindow.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Windows/BaseToolWindow.cs
@@ -29,7 +29,7 @@ namespace Community.VisualStudio.Toolkit
     ///     }
     ///     
     ///     [Guid("d0050678-2e4f-4a93-adcb-af1370da941d")]
-    ///     internal class Pane : ToolWindowPane
+    ///     internal class Pane : ToolkitToolWindowPane
     ///     {
     ///         public Pane()
     ///         {
@@ -164,5 +164,16 @@ namespace Community.VisualStudio.Toolkit
         /// <param name="cancellationToken">The cancellation token to use when performing asynchronous operations.</param>
         /// <returns>The UI element to show in the tool window.</returns>
         public abstract Task<FrameworkElement> CreateAsync(int toolWindowId, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Called when the <see cref="ToolWindowPane"/> has been initialized and "sited". 
+        /// The pane's service provider can be used from this point onwards.
+        /// </summary>
+        /// <param name="pane">The tool window pane that was created.</param>
+        /// <param name="toolWindowId">The ID of the tool window that the pane belongs to.</param>
+        public virtual void SetPane(ToolWindowPane pane, int toolWindowId)
+        {
+            // Consumers can override this if they need access to the pane.
+        }
     }
 }

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Windows/IToolWindowPaneAware.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Windows/IToolWindowPaneAware.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.VisualStudio.Shell;
+
+namespace Community.VisualStudio.Toolkit
+{
+    /// <summary>
+    /// Allows the content of a <see cref="ToolWindowPane"/> to be aware of its owning <see cref="ToolWindowPane"/> object.
+    /// <para>
+    /// Implement this interface on your tool window's content (the object you return from 
+    /// <see cref="BaseToolWindow{T}.CreateAsync(int, System.Threading.CancellationToken)"/>)
+    /// if you need the content object to have access to its <see cref="ToolWindowPane"/>.
+    /// </para>
+    /// </summary>
+    public interface IToolWindowPaneAware
+    {
+        /// <summary>
+        /// Called when the <see cref="ToolWindowPane"/> has been initialized and "sited". 
+        /// The pane's service provider can be used from this point onwards.
+        /// </summary>
+        /// <param name="pane">The tool window pane that was created.</param>
+        void SetPane(ToolWindowPane pane);
+    }
+}

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Windows/IToolWindowProvider.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Windows/IToolWindowProvider.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using Microsoft.VisualStudio.Shell;
 
 namespace Community.VisualStudio.Toolkit
 {
@@ -12,5 +13,7 @@ namespace Community.VisualStudio.Toolkit
         public Type PaneType { get; }
 
         public Task<FrameworkElement> CreateAsync(int toolWindowId, CancellationToken cancellationToken);
+
+        public void SetPane(ToolWindowPane pane, int toolWindowId);
     }
 }

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Windows/ToolkitToolWindowPane.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Windows/ToolkitToolWindowPane.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Microsoft.VisualStudio.Shell;
+
+namespace Community.VisualStudio.Toolkit
+{
+    /// <summary>
+    /// An implementation of <see cref="ToolWindowPane"/> that allows the 
+    /// </summary>
+    public abstract class ToolkitToolWindowPane : ToolWindowPane
+    {
+        private bool _isInitialized;
+
+        /// <inheritdoc/>
+        protected override void Initialize()
+        {
+            base.Initialize();
+            _isInitialized = true;
+            Initialized?.Invoke(this, EventArgs.Empty);
+        }
+
+        internal bool IsInitialized => _isInitialized;
+
+        internal event EventHandler? Initialized;
+    }
+}


### PR DESCRIPTION
Fixes #335.

This change allows a tool window to access the underlying `ToolWindowPane` object, which can then be used to access sited services.

To get access to the pane, you must make your pane inherit from `ToolkitToolWindowPane` instead of `ToolWindowPane`.

If you need to access the pane in your `BaseToolWindow<T>` class, override the `SetPane` method. If you need to access the pane in your tool window's content, make your content (for example, your `UserControl`) implement the `IToolWindowPaneAware` class.

After the tool window is created _and_ the `ToolWindowPane` has been initialized by Visual Studio, the `BaseToolWindow<T>.SetPane` and `IToolWindowPaneAware.SetPane` methods will be called.