### PR TITLE
Add cleaner command attribute check

### DIFF
--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Commands/BaseCommand.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Commands/BaseCommand.cs
@@ -1,6 +1,6 @@
 using System;
 using System.ComponentModel.Design;
-using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
@@ -34,9 +34,7 @@ namespace Community.VisualStudio.Toolkit
         {
             BaseCommand<T> instance = (BaseCommand<T>)(object)new T();
 
-            CommandAttribute? attr = (CommandAttribute)instance.GetType().GetCustomAttributes(typeof(CommandAttribute), true).FirstOrDefault();
-
-            if (attr is null)
+            if (instance.GetType().GetCustomAttribute(typeof(CommandAttribute)) is not CommandAttribute attr)
             {
                 throw new InvalidOperationException($"No [Command(GUID, ID)] attribute was added to {typeof(T).Name}");
             }


### PR DESCRIPTION
Refactors the `CommandAttribute` check in `BaseCommand` to use pattern matching and use `GetCustomAttribute` instead of `GetCustomAttributes`. This results in cleaner and safer code, since `attr` will only be defined when not null.