### PR TITLE
Created a code analyzer to detect commands that have not been initialized

### DIFF
--- a/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Analyzers/CVST005InitializeCommandsAnalyzer.cs
+++ b/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Analyzers/CVST005InitializeCommandsAnalyzer.cs
@@ -1,0 +1,265 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Community.VisualStudio.Toolkit.Analyzers
+{
+    /// <summary>
+    /// Detects commands that have not been initialized.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class CVST005InitializeCommandsAnalyzer : AnalyzerBase
+    {
+        internal const string DiagnosticId = Diagnostics.InitializeCommands;
+        internal const string CommandNameKey = "CommandName";
+
+        private static readonly DiagnosticDescriptor _rule = new(
+            DiagnosticId,
+            GetLocalizableString(nameof(Resources.CVST005_Title)),
+            GetLocalizableString(nameof(Resources.CVST005_MessageFormat)),
+            "Usage",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: GetLocalizableString(nameof(Resources.CVST005_Description)));
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(_rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterCompilationStartAction(OnCompilationStart);
+        }
+
+        private static void OnCompilationStart(CompilationStartAnalysisContext context)
+        {
+            INamedTypeSymbol asyncPackageType;
+            INamedTypeSymbol baseCommandType;
+
+
+            asyncPackageType = context.Compilation.GetTypeByMetadataName(KnownTypeNames.AsyncPackage);
+            baseCommandType = context.Compilation.GetTypeByMetadataName(KnownTypeNames.BaseCommand);
+
+            if ((asyncPackageType is not null) && (baseCommandType is not null))
+            {
+                State state = new(asyncPackageType, baseCommandType);
+
+                context.RegisterSyntaxNodeAction(
+                    (x) => RecordCommandsAndPackages(state, x),
+                    SyntaxKind.ClassDeclaration
+                );
+
+                context.RegisterCompilationEndAction((x) =>
+                {
+                    CheckInitialization(state, x);
+                    state.Dispose();
+                });
+            }
+        }
+
+        private static void RecordCommandsAndPackages(State state, SyntaxNodeAnalysisContext context)
+        {
+            ClassDeclarationSyntax declaration = (ClassDeclarationSyntax)context.Node;
+            INamedTypeSymbol classSymbol = context.SemanticModel.GetDeclaredSymbol(declaration, context.CancellationToken);
+            if (classSymbol is not null)
+            {
+                // Abstract classes cannot be created, which means that even if this class
+                // inherits from `BaseCommand`, it's not a command that can be registered.
+                if (!declaration.Modifiers.Any(SyntaxKind.AbstractKeyword))
+                {
+                    if (IsCommand(classSymbol, state.BaseCommandType))
+                    {
+                        state.Commands[classSymbol] = false;
+                    }
+                }
+
+                if (classSymbol.IsAssignableTo(state.AsyncPackageType))
+                {
+                    state.Packages.Add((declaration, context.SemanticModel));
+                }
+            }
+        }
+
+        private static bool IsCommand(INamedTypeSymbol classType, INamedTypeSymbol baseCommandType)
+        {
+            INamedTypeSymbol? baseType = classType.BaseType;
+            while (baseType is not null)
+            {
+                if (baseType.IsGenericType && baseType.OriginalDefinition.Equals(baseCommandType))
+                {
+                    return true;
+                }
+
+                baseType = baseType.BaseType;
+            }
+
+            return false;
+        }
+
+        private static void CheckInitialization(State state, CompilationAnalysisContext context)
+        {
+            if ((state.Commands.Count == 0) || (state.Packages.Count == 0))
+            {
+                return;
+            }
+
+            bool initializeIndividually = false;
+            foreach ((ClassDeclarationSyntax Class, SemanticModel SemanticModel) package in state.Packages)
+            {
+                switch (CheckInitializationInPackage(package.Class, package.SemanticModel, state.Commands))
+                {
+                    case InitializationMode.Bulk:
+                        // All commands are being initialized in bulk, 
+                        // so we don't need to check anything else.
+                        return;
+
+                    case InitializationMode.Individual:
+                        // Commands are being initialized individually. If we have
+                        // to report diagnostics, we'll tell the code fix that the
+                        // uninitialized commands should be initialized individually.
+                        initializeIndividually = true;
+                        break;
+
+                }
+            }
+
+            if (state.Commands.Any((x) => !x.Value))
+            {
+                // Usually there's only one package, so just
+                // report the diagnostics in the first one.
+                ClassDeclarationSyntax packageToReport = state.Packages
+                    .Select((x) => x.Class)
+                    .OrderBy((x) => x.Identifier.ValueText)
+                    .First();
+
+                MethodDeclarationSyntax? initializeAsyncMethod = FindInitializeAsyncMethod(packageToReport);
+
+                foreach (INamedTypeSymbol command in state.Commands.Where((x) => !x.Value).Select((x) => x.Key))
+                {
+
+                    // If the commands should be initialized individually,
+                    // then we need to include a property in the diagnostic
+                    // that tells the code fix what the name of the command is.
+                    ImmutableDictionary<string, string> properties =
+                        initializeIndividually ?
+                        ImmutableDictionary.CreateRange(new[] { new KeyValuePair<string, string>(CommandNameKey, command.Name) }) :
+                        ImmutableDictionary<string, string>.Empty;
+
+                    context.ReportDiagnostic(
+                        Diagnostic.Create(
+                            _rule,
+                            (initializeAsyncMethod?.Identifier ?? packageToReport.Identifier).GetLocation(),
+                            properties,
+                            command.Name
+                        )
+                    );
+                }
+            }
+        }
+
+        private static InitializationMode? CheckInitializationInPackage(
+            ClassDeclarationSyntax package,
+            SemanticModel semanticModel,
+            ConcurrentDictionary<ISymbol, bool> commands
+        )
+        {
+            InitializationMode? mode = null;
+
+            MethodDeclarationSyntax? initializeAsync = FindInitializeAsyncMethod(package);
+            if (initializeAsync is not null)
+            {
+                foreach (StatementSyntax statement in initializeAsync.Body.Statements)
+                {
+                    if (statement is ExpressionStatementSyntax expression)
+                    {
+                        if (expression.Expression is AwaitExpressionSyntax awaitExpression)
+                        {
+                            if (awaitExpression.Expression is InvocationExpressionSyntax invocation)
+                            {
+                                if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
+                                {
+                                    if (memberAccess.Expression.IsKind(SyntaxKind.ThisExpression))
+                                    {
+                                        if (memberAccess.Name.Identifier.ValueText == "RegisterCommandsAsync")
+                                        {
+                                            // The statement is `this.RegisterCommandsAsync()`.
+                                            return InitializationMode.Bulk;
+                                        }
+                                    }
+                                    else if (memberAccess.Name.Identifier.ValueText == "InitializeAsync")
+                                    {
+                                        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(memberAccess.Expression);
+                                        if (commands.ContainsKey(symbolInfo.Symbol))
+                                        {
+                                            // The statement is `Command.InitializeAsync(package)`.
+                                            commands[symbolInfo.Symbol] = true;
+                                            mode = InitializationMode.Individual;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            return mode;
+        }
+
+        internal static MethodDeclarationSyntax? FindInitializeAsyncMethod(ClassDeclarationSyntax package)
+        {
+            foreach (MethodDeclarationSyntax method in package.Members.OfType<MethodDeclarationSyntax>())
+            {
+                if (method.Modifiers.Any(SyntaxKind.ProtectedKeyword) && method.Modifiers.Any(SyntaxKind.OverrideKeyword))
+                {
+                    if (string.Equals(method.Identifier.ValueText, "InitializeAsync"))
+                    {
+                        return method;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private enum InitializationMode
+        {
+            Individual,
+            Bulk
+        }
+
+        private class State : IDisposable
+        {
+            public State(INamedTypeSymbol asyncPackageType, INamedTypeSymbol baseCommandType)
+            {
+                AsyncPackageType = asyncPackageType;
+                BaseCommandType = baseCommandType;
+            }
+
+            public INamedTypeSymbol AsyncPackageType { get; }
+
+            public INamedTypeSymbol BaseCommandType { get; }
+
+            public ConcurrentDictionary<ISymbol, bool> Commands { get; } = new();
+
+            public ConcurrentBag<(ClassDeclarationSyntax Class, SemanticModel SemanticModel)> Packages { get; } = new();
+
+            public void Dispose()
+            {
+                // ConcurrentBag stores data per-thread, and thata data remains in memory
+                // until it is removed from the bag. Prevent a memory leak by emptying the bag.
+                while (Packages.Count > 0)
+                {
+                    Packages.TryTake(out _);
+                }
+            }
+        }
+    }
+}

--- a/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Analyzers/CVST005InitializeCommandsCodeFixProvider.cs
+++ b/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Analyzers/CVST005InitializeCommandsCodeFixProvider.cs
@@ -1,0 +1,172 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Simplification;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Community.VisualStudio.Toolkit.Analyzers
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CVST005InitializeCommandsCodeFixProvider))]
+    [Shared]
+    public class CVST005InitializeCommandsCodeFixProvider : CodeFixProviderBase
+    {
+        public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(CVST005InitializeCommandsAnalyzer.DiagnosticId);
+
+        public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+            Diagnostic diagnostic = context.Diagnostics.First();
+            TextSpan span = diagnostic.Location.SourceSpan;
+            SyntaxNode node = root.FindToken(span.Start).Parent;
+
+            if (node is ClassDeclarationSyntax declaration)
+            {
+                // There is no `InitializeAsync()` method, so the diagnostic
+                // was reported on the class declaration. To fix all of the 
+                // diagnostics, we can create the `InitializeAsync()` method.
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        Resources.CVST005_CodeFix,
+                        cancellation => AddInitializeAsyncMethodAsync(context.Document, declaration, cancellation),
+                        equivalenceKey: nameof(Resources.CVST001_CodeFix)
+                    ),
+                    diagnostic
+                );
+            }
+            else if (node is MethodDeclarationSyntax method)
+            {
+                // There is an `InitializeAsync()` method. We can fix the
+                // diagnostics by adding statements to that method. If each
+                // diagnostic contains a property for the command name, then
+                // we need to register the commands individually. If no name
+                // is specified, then we can initialize all commands in bulk.
+                if (context.Diagnostics.All((x) => x.Properties.ContainsKey(CVST005InitializeCommandsAnalyzer.CommandNameKey)))
+                {
+                    List<string> commandNames = context.Diagnostics
+                        .Select((x) => x.Properties[CVST005InitializeCommandsAnalyzer.CommandNameKey])
+                        .ToList();
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            Resources.CVST005_CodeFix,
+                            cancellation => InitializeSpecificCommandsAsync(context.Document, method, commandNames, cancellation),
+                            equivalenceKey: nameof(Resources.CVST001_CodeFix)
+                        ),
+                        diagnostic
+                    );
+                }
+                else
+                {
+                    // The command names weren't specified in the diagnostic, which means
+                    // that no existing commands are being initialized. We can choose to 
+                    // initialize the command individually or initialize all commands
+                    // in bulk. We'll choose the bulk method because it's shorter.
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            Resources.CVST005_CodeFix,
+                            cancellation => InitializeAllCommandsAsync(context.Document, method, cancellation),
+                            equivalenceKey: nameof(Resources.CVST001_CodeFix)
+                        ),
+                        diagnostic
+                    );
+                }
+            }
+        }
+
+        private async Task<Document> AddInitializeAsyncMethodAsync(Document document, ClassDeclarationSyntax declaration, CancellationToken cancellationToken)
+        {
+            SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken);
+            SyntaxEditor editor = new(root, document.Project.Solution.Workspace);
+            SyntaxGenerator generator = editor.Generator;
+
+            editor.AddMember(
+                declaration,
+                generator.MethodDeclaration(
+                    "InitializeAsync",
+                    parameters: new[] {
+                        generator.ParameterDeclaration("cancellationToken",SyntaxFactory.ParseTypeName("System.Threading.CancellationToken")),
+                        generator.ParameterDeclaration("progress", SyntaxFactory.ParseTypeName("System.IProgress<Microsoft.VisualStudio.Shell.ServiceProgressData>"))
+                    },
+                    returnType: SyntaxFactory.ParseTypeName("System.Threading.Tasks.Task"),
+                    accessibility: Accessibility.Protected,
+                    modifiers: DeclarationModifiers.Override | DeclarationModifiers.Async,
+                    statements: new[] {
+                        generator.AwaitExpression(
+                            generator.InvocationExpression(
+                                generator.MemberAccessExpression(
+                                    generator.ThisExpression(),
+                                    "RegisterCommandsAsync"
+                                )
+                            )
+                        )
+                    }
+                ).WithAdditionalAnnotations(Simplifier.Annotation)
+            );
+
+            return document.WithSyntaxRoot(editor.GetChangedRoot());
+        }
+
+        private async Task<Document> InitializeAllCommandsAsync(Document document, MethodDeclarationSyntax initializeAsyncMethod, CancellationToken cancellationToken)
+        {
+            SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken);
+            SyntaxEditor editor = new(root, document.Project.Solution.Workspace);
+            SyntaxGenerator generator = editor.Generator;
+
+            editor.SetStatements(
+                initializeAsyncMethod,
+                initializeAsyncMethod.Body.Statements.Add(
+                    (StatementSyntax)generator.ExpressionStatement(
+                        generator.AwaitExpression(
+                            generator.InvocationExpression(
+                                generator.MemberAccessExpression(
+                                    generator.ThisExpression(),
+                                    "RegisterCommandsAsync"
+                                )
+                            )
+                        )
+                    ).WithAdditionalAnnotations(Simplifier.Annotation)
+                )
+            );
+
+            return document.WithSyntaxRoot(editor.GetChangedRoot());
+        }
+
+        private async Task<Document> InitializeSpecificCommandsAsync(Document document, MethodDeclarationSyntax initializeAsyncMethod, IEnumerable<string> commandNames, CancellationToken cancellationToken)
+        {
+            SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken);
+            SyntaxEditor editor = new(root, document.Project.Solution.Workspace);
+            SyntaxGenerator generator = editor.Generator;
+
+            editor.SetStatements(
+                initializeAsyncMethod,
+                initializeAsyncMethod.Body.Statements.AddRange(
+                    commandNames.Select((name) => (StatementSyntax)generator.ExpressionStatement(
+                        generator.AwaitExpression(
+                            generator.InvocationExpression(
+                                generator.MemberAccessExpression(
+                                    SyntaxFactory.ParseTypeName(name),
+                                    "InitializeAsync"
+                                ),
+                                generator.ThisExpression()
+                            )
+                        )
+                    ).WithAdditionalAnnotations(Simplifier.Annotation)
+                ))
+            );
+
+            return document.WithSyntaxRoot(editor.GetChangedRoot());
+        }
+
+    }
+}

--- a/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Diagnostics.cs
+++ b/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Diagnostics.cs
@@ -6,5 +6,6 @@
         public const string DialogPageShouldBeComVisible = "CVST002";
         public const string UseCorrectTypeInProvideOptionDialogPageAttribute = "CVST003";
         public const string UseCorrectTypeInProvideProfileAttribute = "CVST004";
+        public const string InitializeCommands = "CVST005";
     }
 }

--- a/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/KnownTypeNames.cs
+++ b/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/KnownTypeNames.cs
@@ -2,6 +2,8 @@
 {
     internal static class KnownTypeNames
     {
+        public const string AsyncPackage = "Microsoft.VisualStudio.Shell.AsyncPackage";
+        public const string BaseCommand = "Community.VisualStudio.Toolkit.BaseCommand`1";
         public const string ComVisibleAttribute = "System.Runtime.InteropServices.ComVisibleAttribute";
         public const string DialogPage = "Microsoft.VisualStudio.Shell.DialogPage";
         public const string IProfileManager = "Microsoft.VisualStudio.Shell.IProfileManager";

--- a/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Resources.Designer.cs
+++ b/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Resources.Designer.cs
@@ -143,6 +143,42 @@ namespace Community.VisualStudio.Toolkit.Analyzers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Initialize the commands.
+        /// </summary>
+        internal static string CVST005_CodeFix {
+            get {
+                return ResourceManager.GetString("CVST005_CodeFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Commands should be initialized when the package is initialized.
+        /// </summary>
+        internal static string CVST005_Description {
+            get {
+                return ResourceManager.GetString("CVST005_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The command &apos;{0}&apos; has not been initialized.
+        /// </summary>
+        internal static string CVST005_MessageFormat {
+            get {
+                return ResourceManager.GetString("CVST005_MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Register commands.
+        /// </summary>
+        internal static string CVST005_Title {
+            get {
+                return ResourceManager.GetString("CVST005_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Change to &apos;{0}&apos;.
         /// </summary>
         internal static string IncorrectProvidedType_CodeFix {

--- a/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Resources.resx
+++ b/src/analyzers/Community.VisualStudio.Toolkit.Analyzers/Resources.resx
@@ -144,6 +144,18 @@
   <data name="CVST004_Title" xml:space="preserve">
     <value>Register correct type in ProvideProfileAttribute</value>
   </data>
+  <data name="CVST005_CodeFix" xml:space="preserve">
+    <value>Initialize the commands</value>
+  </data>
+  <data name="CVST005_Description" xml:space="preserve">
+    <value>Commands should be initialized when the package is initialized</value>
+  </data>
+  <data name="CVST005_MessageFormat" xml:space="preserve">
+    <value>The command '{0}' has not been initialized</value>
+  </data>
+  <data name="CVST005_Title" xml:space="preserve">
+    <value>Register commands</value>
+  </data>
   <data name="IncorrectProvidedType_CodeFix" xml:space="preserve">
     <value>Change to '{0}'</value>
   </data>

--- a/test/analyzers/Community.VisualStudio.Toolkit.Analyzers.UnitTests/Analyzers/CVST005InitializeCommandsAnalyzerTests.cs
+++ b/test/analyzers/Community.VisualStudio.Toolkit.Analyzers.UnitTests/Analyzers/CVST005InitializeCommandsAnalyzerTests.cs
@@ -1,0 +1,179 @@
+﻿using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Xunit;
+
+namespace Community.VisualStudio.Toolkit.Analyzers.UnitTests.Analyzers
+{
+    public class CVST005InitializeCommandsAnalyzerTests : TestBase<CVST005InitializeCommandsAnalyzer, CVST005InitializeCommandsCodeFixProvider>
+    {
+        private const string _usings = @"
+using Community.VisualStudio.Toolkit;
+using Microsoft.VisualStudio.Shell;
+using System;
+using System.Threading;
+using System.Threading.Tasks;";
+
+        public CVST005InitializeCommandsAnalyzerTests()
+        {
+            AddReference(typeof(BaseCommand<>));
+            AddReference(typeof(AsyncPackage));
+            AddReference(typeof(ServiceProgressData));
+        }
+
+        [Fact]
+        public async Task DoesNotReportDiagnosticWhenCommandsIsInitializedDirectlyAsync()
+        {
+            TestCode = _usings + @"
+
+class MyCommand : BaseCommand<MyCommand> { }
+
+class MyPackage : AsyncPackage
+{
+    protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+    {
+        await MyCommand.InitializeAsync(this);
+    }
+}
+";
+
+            await VerifyAsync();
+        }
+
+        [Fact]
+        public async Task DoesNotReportDiagnosticWhenCommandsAreInitializedInBulkAsync()
+        {
+            TestCode = _usings + @"
+
+class MyCommand : BaseCommand<MyCommand> { }
+
+class MyPackage : AsyncPackage
+{
+    protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+    {
+        await this.RegisterCommandsAsync();
+    }
+}
+";
+
+            await VerifyAsync();
+        }
+
+        [Fact]
+        public async Task ReportsDiagnosticWhenNoCommandsAreInitializedAsync()
+        {
+            TestCode = _usings + @"
+
+class MyFirstCommand : BaseCommand<MyFirstCommand> { }
+class MySecondCommand : BaseCommand<MySecondCommand> { }
+
+class MyPackage : AsyncPackage
+{
+    protected override async Task {|#0:{|#1:InitializeAsync|}|}(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+    {
+        System.Diagnostics.Debug.WriteLine(""Initializing"");
+    }
+}
+";
+
+            FixedCode = _usings + @"
+
+class MyFirstCommand : BaseCommand<MyFirstCommand> { }
+class MySecondCommand : BaseCommand<MySecondCommand> { }
+
+class MyPackage : AsyncPackage
+{
+    protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+    {
+        System.Diagnostics.Debug.WriteLine(""Initializing"");
+        await this.RegisterCommandsAsync();
+    }
+}
+";
+
+            Expect(
+                Diagnostic(Diagnostics.InitializeCommands)
+                .WithLocation(0)
+                .WithArguments("MyFirstCommand"));
+
+            Expect(
+                Diagnostic(Diagnostics.InitializeCommands)
+                .WithLocation(1)
+                .WithArguments("MySecondCommand"));
+
+            await VerifyAsync();
+        }
+
+        [Fact]
+        public async Task ReportsDiagnosticWhenSomeCommandsAreInitializedAsync()
+        {
+            TestCode = _usings + @"
+
+class MyFirstCommand : BaseCommand<MyFirstCommand> { }
+class MySecondCommand : BaseCommand<MySecondCommand> { }
+
+class MyPackage : AsyncPackage
+{
+    protected override async Task {|#0:InitializeAsync|}(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+    {
+        await MyFirstCommand.InitializeAsync(this);
+    }
+}
+";
+
+            FixedCode = _usings + @"
+
+class MyFirstCommand : BaseCommand<MyFirstCommand> { }
+class MySecondCommand : BaseCommand<MySecondCommand> { }
+
+class MyPackage : AsyncPackage
+{
+    protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+    {
+        await MyFirstCommand.InitializeAsync(this);
+        await MySecondCommand.InitializeAsync(this);
+    }
+}
+";
+
+            Expect(
+                Diagnostic(Diagnostics.InitializeCommands)
+                .WithLocation(0)
+                .WithArguments("MySecondCommand"));
+
+            await VerifyAsync();
+        }
+
+        [Fact]
+        public async Task ReportsDiagnosticWhenInitializeAsyncMethodDoesNotExistAsync()
+        {
+            TestCode = _usings + @"
+
+class MyCommand : BaseCommand<MyCommand> { }
+
+class {|#0:MyPackage|} : AsyncPackage
+{
+}
+";
+
+            FixedCode = _usings + @"
+
+class MyCommand : BaseCommand<MyCommand> { }
+
+class MyPackage : AsyncPackage
+{
+    protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+    {
+        await this.RegisterCommandsAsync();
+    }
+}
+";
+
+            Expect(
+                Diagnostic(Diagnostics.InitializeCommands)
+                .WithLocation(0)
+                .WithArguments("MyCommand"));
+
+            await VerifyAsync();
+        }
+    }
+}


### PR DESCRIPTION
Related to https://github.com/VsixCommunity/Community.VisualStudio.Toolkit/discussions/349#discussioncomment-2979674

This new code analyzer will detect when a command has not been initialized in the package's `InitializeAsync` method. The code fix works in one of two ways:
1. If any other command is being registered directly using `MyExistingCommand.Initialize(package)`, then the code fix will add a call to `MyUninitializedCommand.Initialize(package)` (where `MyUninitializedCommand` was the command that was not initialized).
2. If no other commands are being registered, the code fix will add a call to `this.RegisterCommandsAsync()`.