### PR TITLE
Fixed some compiler warnings

### DIFF
--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/MEF/TokenOutliningTaggerBase.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/MEF/TokenOutliningTaggerBase.cs
@@ -57,7 +57,7 @@ namespace Community.VisualStudio.Toolkit
                         guideLineHorizontalAnchor: span.Start,
                         type: PredefinedStructureTagTypes.Structural,
                         isCollapsible: true,
-                        collapsedForm: tag.GetOutliningText(text),
+                        collapsedForm: tag.GetOutliningText!(text),
                         collapsedHintForm: null);
 
             return new TagSpan<IStructureTag>(span, structureTag);

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Notifications/RatingPrompt.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Notifications/RatingPrompt.cs
@@ -125,6 +125,8 @@ namespace Community.VisualStudio.Toolkit
         /// </summary>
         public async Task PromptAsync()
         {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+           
             InfoBar? infoBar = await CreateInfoBarAsync();
 
             if (infoBar == null)

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Windows/WindowFrame.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Windows/WindowFrame.cs
@@ -231,6 +231,8 @@ namespace Community.VisualStudio.Toolkit
         /// <returns><see langword="null"/> if the window isn't a document window.</returns>
         public async Task<DocumentView?> GetDocumentViewAsync()
         {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+           
             // Force the loading of a document that may be pending initialization.
             // See https://docs.microsoft.com/en-us/visualstudio/extensibility/internals/delayed-document-loading
             _frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out _);


### PR DESCRIPTION
I noticed a few compiler warnings.

```
Notifications\RatingPrompt.cs(137,21): warning VSTHRD010: Accessing "Community.VisualStudio.Toolkit.InfoBar.TryGetWpfElement" should only be done on the main thread. Await JoinableTaskFactory.SwitchToMainThreadAsync() first.

Notifications\RatingPrompt.cs(148,21): warning VSTHRD010: Accessing "Community.VisualStudio.Toolkit.InfoBar.Close" should only be done on the main thread. Await JoinableTaskFactory.SwitchToMainThreadAsync() first.

Windows\WindowFrame.cs(236,20): warning VSTHRD010: Accessing "IVsWindowFrame" should only be done on the main thread. Await JoinableTaskFactory.SwitchToMainThreadAsync() first.

MEF\TokenOutliningTaggerBase.cs(60,40): warning CS8602: Dereference of a possibly null reference.
```