### PR TITLE
Using InfoBar listener cookie

### DIFF
--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Notifications/InfoBar.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Notifications/InfoBar.cs
@@ -113,7 +113,7 @@ namespace Community.VisualStudio.Toolkit
         /// <summary>
         /// Displays the InfoBar in the tool window or document previously specified.
         /// </summary>
-        /// <returns><c>true</c> if the InfoBar was shown; otherwise <c>false</c>.</returns>
+        /// <returns><see langword="true" /> if the InfoBar was shown; otherwise <see langword="false" />.</returns>
         public async Task<bool> TryShowInfoBarUIAsync()
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -132,7 +132,7 @@ namespace Community.VisualStudio.Toolkit
         }
 
         /// <summary>
-        /// Attempts to get the underlying WPF UI element of the InfoBar
+        /// Attempts to get the underlying WPF UI element of the InfoBar.
         /// </summary>
         public bool TryGetWpfElement(out Control? control)
         {

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Notifications/InfoBar.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Notifications/InfoBar.cs
@@ -94,6 +94,7 @@ namespace Community.VisualStudio.Toolkit
         private readonly IVsInfoBarHost _host;
         private readonly InfoBarModel _model;
         private IVsInfoBarUIElement? _uiElement;
+        private uint _listenerCookie;
 
         /// <summary>
         /// Creates a new instance of the InfoBar in a specific window frame or document window.
@@ -119,7 +120,7 @@ namespace Community.VisualStudio.Toolkit
             IVsInfoBarUIFactory infoBarUIFactory = (IVsInfoBarUIFactory)await VS.GetRequiredServiceAsync<SVsInfoBarUIFactory, object>();
 
             _uiElement = infoBarUIFactory.CreateInfoBar(_model);
-            _uiElement.Advise(this, out _);
+            _uiElement.Advise(this, out _listenerCookie);
 
             if (_host != null)
             {
@@ -171,6 +172,7 @@ namespace Community.VisualStudio.Toolkit
         void IVsInfoBarUIEvents.OnClosed(IVsInfoBarUIElement infoBarUIElement)
         {
             IsVisible = false;
+            _uiElement?.Unadvise(_listenerCookie);
         }
 
         void IVsInfoBarUIEvents.OnActionItemClicked(IVsInfoBarUIElement infoBarUIElement, IVsInfoBarActionItem actionItem)


### PR DESCRIPTION
When subscribing to UI events for an `InfoBar`, the code is currently discarding the listener cookie, but this cookie should be used to later unsubscribe the event sink when closing the gold bar.

I also made some nit changes on the XAML docs, keeping consistency across the repo (e.g.: [Here](https://github.com/VsixCommunity/Community.VisualStudio.Toolkit/blob/9c32305c83827d0bfd7c85777f9e79fc71e22c2b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Commands/Commands.cs#L39) we use `<see langword="true" />` instead of `<c>true</c>`).