### PR TITLE
Fixed ShutdownStarted event never firing

### DIFF
--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Shell/ShellEvents.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Shell/ShellEvents.cs
@@ -61,7 +61,7 @@ namespace Community.VisualStudio.Toolkit
             }
             else if (propid == (int)__VSSPROPID6.VSSPROPID_ShutdownStarted)
             {
-                if (!(bool)var)
+                if ((bool)var)
                 {
                     ShutdownStarted?.Invoke();
                 }


### PR DESCRIPTION
I'm not able to get the ShutdownStarted event to fire. Currently, it only triggers the event when __VSSPROPID6.VSSPROPID_ShutdownStarted is false. Checking the documentation (https://learn.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.interop.__vsspropid6?view=visualstudiosdk-2022) it looks like the value should be true when Visual Studio is shutting down. With this change, it now triggers like I'd expect it to.