### PR TITLE
Always try to write attribute to project file if property descriptor is not available

### DIFF
--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Solution/PhysicalFile.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Solution/PhysicalFile.cs
@@ -146,8 +146,9 @@ namespace Community.VisualStudio.Toolkit
                     return true;
                 }
             }
-            // Then write straight to project file
-            else if (hierarchy is IVsBuildPropertyStorage storage)
+
+            // If the property descriptor was not available, then write straight to the project file.
+            if (hierarchy is IVsBuildPropertyStorage storage)
             {
                 ErrorHandler.ThrowOnFailure(storage.SetItemAttribute(itemId, name, value?.ToString()));
                 return true;


### PR DESCRIPTION
When setting a file attribute, if the `VSHPROPID_BrowseObject` property could be retrieved, but there wasn't a property descriptor for the specified attribute, then the attribute would not be set. Now, if will always fall back to writing the attribute to `IVsBuildPropertyStorage`.

Related to #383.