### PR TITLE
The HighLigth word feature stopped working after the window was split…

### DIFF
--- a/demo/VSSDK.TestExtension/MEF/HighlightWord.cs
+++ b/demo/VSSDK.TestExtension/MEF/HighlightWord.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.VisualStudio.Text.Operations;
+using Microsoft.VisualStudio.Text.Tagging;
+using Microsoft.VisualStudio.Utilities;
+using Community.VisualStudio.Toolkit;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Text.Editor;
+
+namespace TestExtension.MEF
+{
+    /// <summary>
+    /// This class demonstrates a HighlightWord tagger for text files
+    /// and it only highlights whole words starting with a Letter
+    /// </summary>
+    [Export(typeof(IViewTaggerProvider))]
+    [ContentType("Text")]
+    [TagType(typeof(TextMarkerTag))]
+    [TextViewRole(PredefinedTextViewRoles.PrimaryDocument)]
+    internal class HighlightWordTaggerProvider : SameWordHighlighterBase
+    {
+        public override FindOptions FindOptions => FindOptions.WholeWord;
+        public override bool ShouldHighlight(string text)
+        {
+            if (text?.Length > 0)
+                return char.IsLetter(text[0]);
+            return false;
+        }
+
+    }
+}

--- a/demo/VSSDK.TestExtension/VSSDK.TestExtension.csproj
+++ b/demo/VSSDK.TestExtension/VSSDK.TestExtension.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Commands\RunnerWindowCommand.cs" />
     <Compile Include="Commands\ThemeWindowCommand.cs" />
     <Compile Include="Commands\UnloadSelectedProject.cs" />
+    <Compile Include="MEF\HighlightWord.cs" />
     <Compile Include="MEF\TextViewCreationListener.cs" />
     <Compile Include="Options\General.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
… and unsplit or after the preview margin was shown because these all share the same buffer.

We now add a counter to the SameWordHighlighterTagger and when the Counter reaches zero then the tagger stops tagging. Also added a HighlightWord tagger to the example project that tags words inside text documents.