### PR TITLE
Ensured that dynamic menu items are visible and enabled by default

### DIFF
--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Commands/BaseDynamicCommand.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Commands/BaseDynamicCommand.cs
@@ -67,6 +67,13 @@ namespace Community.VisualStudio.Toolkit
             // is out of bounds, then we'll hide and disable the menu item.
             if (TryGetItem(index, out TItem item))
             {
+                // If there are no items, then each dynamic menu item will be disabled and
+                // hidden in the `else` case below. We don't want to rely on `BeforeQueryStatus`
+                // having to make the menu items enabled and visible, so we will make them enabled
+                // and visible by default, and `BeforeQueryStatus` can change that if it needs to.
+                menuItem.Enabled = true;
+                menuItem.Visible = true;
+
                 BeforeQueryStatus(menuItem, e, item);
 
                 // Store the index in the menu item's properties so that we can


### PR DESCRIPTION
If you have a dynamic command and at some point there are no dynamic items to display, then after that point the dynamic menu items will no longer appear, even when there are dynamic items to display.

This occurred because when there are no dynamic items, all of the menu items are hidden and disabled (otherwise you would end up with a single menu item that shouldn't be there). If at some point after that there are dynamic items again, the menu items would remain disabled and hidden unless the `BeforeQueryStatus` handler specifically set the menu item to be enabled and visible.

You can reproduce this bug in the test extension (without this fix, of course):
1. Open a solution with a few projects.
2. Open the _Extensions / VSSDK Test Extension / Edit Project File_ menu. You should see each loaded project in the menu.
3. Unload all of the projects in the solution.
4. Open the _Extensions / VSSDK Test Extension_ menu. The _Edit Project File_ menu should not be visible because there are no projects.
5. Now load at least one project.
6. Open the _Extensions / VSSDK Test Extension_ menu. The _Edit Project File_ menu _should_ be visible but it's not.