### PR TITLE
Allow command interceptors to be unregistered

### DIFF
--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Helpers/Disposable.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Helpers/Disposable.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace Community.VisualStudio.Toolkit
+{
+    internal sealed class Disposable : IDisposable
+    {
+        private readonly Action _action;
+        private bool _disposed;
+
+        public Disposable(Action action)
+        {
+            _action = action;
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+                _action();
+            }
+        }
+    }
+}

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Debugger\Debugger.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\Disposable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows\IToolWindowPaneAware.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows\ToolkitToolWindowPane.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)\Attributes\ProvideBraceCompletionAttribute.cs" />


### PR DESCRIPTION
This PR changes `Commands.InterceptAsync` to return a `Task<IDisposable>`. When you dispose of the returned object, the command interceptor will be unregistered.