### PR TITLE
[Breaking Changes] Fix FrameShow enum

### DIFF
--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Windows/WindowFrame.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Windows/WindowFrame.cs
@@ -442,12 +442,8 @@ namespace Community.VisualStudio.Toolkit
     /// </summary>
     public enum FrameShow
     {
-        /// <summary>Reason unknown</summary>
-        Unknown = 0,
-        /// <summary>Obsolete; use WinHidden.</summary>
-        Hidden = __FRAMESHOW.FRAMESHOW_Hidden,
         /// <summary>Window (tabbed or otherwise) is hidden.</summary>
-        WinHidden = __FRAMESHOW.FRAMESHOW_WinHidden,
+        Hidden = __FRAMESHOW.FRAMESHOW_WinHidden,
         /// <summary>A nontabbed window is made visible.</summary>
         Shown = __FRAMESHOW.FRAMESHOW_WinShown,
         /// <summary>A tabbed window is activated (made visible).</summary>

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Windows/WindowFrame.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Windows/WindowFrame.cs
@@ -1,4 +1,4 @@
-﻿// ================================================================================================
+// ================================================================================================
 // WindowFrame.cs
 //
 // Created: 2008.07.02, by Istvan Novak (DeepDiver)
@@ -440,7 +440,6 @@ namespace Community.VisualStudio.Toolkit
     /// <summary>
     /// Specifies options when the show state of a window frame changes.
     /// </summary>
-    [Flags]
     public enum FrameShow
     {
         /// <summary>Reason unknown</summary>

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Windows/WindowFrame.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Windows/WindowFrame.cs
@@ -1,4 +1,4 @@
-// ================================================================================================
+﻿// ================================================================================================
 // WindowFrame.cs
 //
 // Created: 2008.07.02, by Istvan Novak (DeepDiver)
@@ -440,6 +440,13 @@ namespace Community.VisualStudio.Toolkit
     /// <summary>
     /// Specifies options when the show state of a window frame changes.
     /// </summary>
+    /// <remarks>
+    /// This combines the values from 
+    /// <see cref="__FRAMESHOW"/>, 
+    /// <see cref="__FRAMESHOW2"/>, 
+    /// <see cref="__FRAMESHOW3"/> and 
+    /// <see cref="__FRAMESHOW4"/>.
+    /// </remarks>
     public enum FrameShow
     {
         /// <summary>
@@ -486,7 +493,32 @@ namespace Community.VisualStudio.Toolkit
         /// <para>Auto-hidden window is about to slide into view.</para>
         /// <para>Equivalent to <see cref="__FRAMESHOW.FRAMESHOW_AutoHideSlideBegin"/>.</para>
         /// </summary>
-        AutoHideSlideBegin = __FRAMESHOW.FRAMESHOW_AutoHideSlideBegin
+        AutoHideSlideBegin = __FRAMESHOW.FRAMESHOW_AutoHideSlideBegin,
+        /// <summary>
+        /// <para>A window is about to be hidden.</para>
+        /// <para>Equivalent to <see cref="__FRAMESHOW2.FRAMESHOW_BeforeWinHidden"/>.</para>
+        /// </summary>
+        BeforeHidden = __FRAMESHOW2.FRAMESHOW_BeforeWinHidden,
+        /// <summary>
+        /// <para>Auto-hidden window is finished sliding into view.</para>
+        /// <para>Equivalent to <see cref="__FRAMESHOW2.FRAMESHOW_AutoHideSlideEnd"/>.</para>
+        /// </summary>
+        AutoHideSlideEnd = __FRAMESHOW2.FRAMESHOW_AutoHideSlideEnd,
+        /// <summary>
+        /// <para>A window is activated (made visible).</para>
+        /// <para>Equivalent to <see cref="__FRAMESHOW3.FRAMESHOW_WinActivated"/>.</para>
+        /// </summary>
+        Activated = __FRAMESHOW3.FRAMESHOW_WinActivated,
+        /// <summary>
+        /// <para>The window's inner content received keyboard focus.</para>
+        /// <para>Equivalent to <see cref="__FRAMESHOW4.FRAMESHOW_WinContentGotFocus"/>.</para>
+        /// </summary>
+        ContentGotFocus = __FRAMESHOW4.FRAMESHOW_WinContentGotFocus,
+        /// <summary>
+        /// <para>The window's inner content lost keyboard focus.</para>
+        /// <para>Equivalent to <see cref="__FRAMESHOW4.FRAMESHOW_WinContentLostFocus"/>.</para>
+        /// </summary>
+        ContentLostFocus = __FRAMESHOW4.FRAMESHOW_WinContentLostFocus
     }
 
     /// <summary>
@@ -573,4 +605,16 @@ namespace Community.VisualStudio.Toolkit
             Docked = docked;
         }
     }
+
+
+#if VS14
+    /// <summary>
+    /// __FRAMESHOW4 was first defined in Visual Studio 15.
+    /// </summary>
+    internal enum __FRAMESHOW4
+    {
+        FRAMESHOW_WinContentGotFocus = 13,
+        FRAMESHOW_WinContentLostFocus
+    }
+#endif
 }

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Windows/WindowFrame.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Windows/WindowFrame.cs
@@ -232,7 +232,7 @@ namespace Community.VisualStudio.Toolkit
         public async Task<DocumentView?> GetDocumentViewAsync()
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-           
+
             // Force the loading of a document that may be pending initialization.
             // See https://docs.microsoft.com/en-us/visualstudio/extensibility/internals/delayed-document-loading
             _frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out _);
@@ -442,23 +442,50 @@ namespace Community.VisualStudio.Toolkit
     /// </summary>
     public enum FrameShow
     {
-        /// <summary>Window (tabbed or otherwise) is hidden.</summary>
+        /// <summary>
+        /// <para>Window (tabbed or otherwise) is hidden.</para>
+        /// <para>Equivalent to <see cref="__FRAMESHOW.FRAMESHOW_WinHidden"/>.</para>
+        /// </summary>
         Hidden = __FRAMESHOW.FRAMESHOW_WinHidden,
-        /// <summary>A nontabbed window is made visible.</summary>
+        /// <summary>
+        /// <para>A non-tabbed window is made visible.</para>
+        /// <para>Equivalent to <see cref="__FRAMESHOW.FRAMESHOW_WinShown"/>.</para>
+        /// </summary>
         Shown = __FRAMESHOW.FRAMESHOW_WinShown,
-        /// <summary>A tabbed window is activated (made visible).</summary>
+        /// <summary>
+        /// <para>A tabbed window is activated (made visible).</para>
+        /// <para>Equivalent to <see cref="__FRAMESHOW.FRAMESHOW_TabActivated"/>.</para>
+        /// </summary>
         TabActivated = __FRAMESHOW.FRAMESHOW_TabActivated,
-        /// <summary>A tabbed window is deactivated.</summary>
+        /// <summary>
+        /// <para>A tabbed window is deactivated.</para>
+        /// <para>Equivalent to <see cref="__FRAMESHOW.FRAMESHOW_TabDeactivated"/>.</para>
+        /// </summary>
         TabDeactivated = __FRAMESHOW.FRAMESHOW_TabDeactivated,
-        /// <summary>Window is restored to normal state.</summary>
+        /// <summary>
+        /// <para>Window is restored to normal state.</para>
+        /// <para>Equivalent to <see cref="__FRAMESHOW.FRAMESHOW_WinRestored"/>.</para>
+        /// </summary>
         Restored = __FRAMESHOW.FRAMESHOW_WinRestored,
-        /// <summary>Window is minimized.</summary>
+        /// <summary>
+        /// <para>Window is minimized.</para>
+        /// <para>Equivalent to <see cref="__FRAMESHOW.FRAMESHOW_WinMinimized"/>.</para>
+        /// </summary>
         Minimized = __FRAMESHOW.FRAMESHOW_WinMinimized,
-        /// <summary>Window is maximized.</summary>
+        /// <summary>
+        /// <para>Window is maximized.</para>
+        /// <para>Equivalent to <see cref="__FRAMESHOW.FRAMESHOW_WinMaximized"/>.</para>
+        /// </summary>
         Maximized = __FRAMESHOW.FRAMESHOW_WinMaximized,
-        /// <summary>Multi-instance tool window destroyed.</summary>
+        /// <summary>
+        /// <para>Multi-instance tool window destroyed.</para>
+        /// <para>Equivalent to <see cref="__FRAMESHOW.FRAMESHOW_DestroyMultInst"/>.</para>
+        /// </summary>
         DestroyMultipleInstance = __FRAMESHOW.FRAMESHOW_DestroyMultInst,
-        /// <summary>Autohidden window is about to slide into view.</summary>
+        /// <summary>
+        /// <para>Auto-hidden window is about to slide into view.</para>
+        /// <para>Equivalent to <see cref="__FRAMESHOW.FRAMESHOW_AutoHideSlideBegin"/>.</para>
+        /// </summary>
         AutoHideSlideBegin = __FRAMESHOW.FRAMESHOW_AutoHideSlideBegin
     }
 


### PR DESCRIPTION
🚨 **This contains breaking changes** 🚨 

A few improvements to the `FrameShow` enum. Hopefully the breaking changes won't actually affect anyone. 🤞 

1. It was marked with the `[Flags]` attribute. The underlying `__FRAMESHOW` enum is not flagged.

2. There was a redundant `Unknown` member with a value of zero. That is equivalent to both `FRAMESHOW_Hidden` and `FRAMESHOW_WinHidden`. I've removed `Unknown`. **This is a breaking change.**

3. `FRAMESHOW_Hidden` is documented as being obsolete and has the same value as `FRAMESHOW_WinHidden`. I've removed `WinHidden` rather than `Hidden` because there is no corresponding `WinShown` value (but there is a `Shown` value). **This is a breaking change.**

4. I've added enum values for [`__FRAMESHOW2`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.interop.__frameshow2?view=visualstudiosdk-2022), [`__FRAMESHOW3`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.interop.__frameshow3?view=visualstudiosdk-2022) and [`__FRAMESHOW4`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.interop.__frameshow4?view=visualstudiosdk-2022).

5. I've added a comment to the `<summary>` tag that specifies the underlying enum value. When I was trying to understand which value I should be using, I found myself searching the web for examples. First I had to discover the Visual Studio enum that `FrameShow` is actually wrapping, and then find the corresponding enum member name. It would have been much easier if it was all available in the documentation comments. 
 
ℹ️ One thing about the documentation comments that I noticed - when the enum is used within the same solution as the toolkit, intellisense actually shows the value assigned to the enum, like so:
![image](https://user-images.githubusercontent.com/10321525/219352651-21b71202-99e6-4fcc-9567-cafa7462e198.png)
But when you're referencing the actual NuGet packages, intellisense only tells you the numeric value:
![image](https://user-images.githubusercontent.com/10321525/219352342-e0ba189c-0b07-4b31-b323-a239094f4331.png)
Hence why I've added the underlying enum member to the documentation. 😄 