### PR TITLE
Make sure only a single SameWordHighlighter is attached to a textbuffer.

### DIFF
--- a/demo/VSSDK.TestExtension/MEF/HighlightWord.cs
+++ b/demo/VSSDK.TestExtension/MEF/HighlightWord.cs
@@ -4,9 +4,25 @@ using Microsoft.VisualStudio.Utilities;
 using Community.VisualStudio.Toolkit;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Text.Editor;
-
+using Microsoft.VisualStudio.Text.Classification;
+using System.Windows.Media;
 namespace TestExtension.MEF
 {
+    
+    [Export(typeof(EditorFormatDefinition))]
+    [Name("MarkerFormatDefinition/HighlightWordFormatDefinition")]
+    [UserVisible(true)]
+    internal class HighlightWordFormatDefinition : MarkerFormatDefinition
+    {
+        public HighlightWordFormatDefinition()
+        {
+            this.BackgroundColor = Colors.LightBlue;
+            this.ForegroundColor = Colors.DarkBlue;
+            this.DisplayName = "Highlight Word";
+            this.ZOrder = 5;
+        }
+    }
+
     /// <summary>
     /// This class demonstrates a HighlightWord tagger for text files
     /// and it only highlights whole words starting with a Letter

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/MEF/SameWordHighlighterBase.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/MEF/SameWordHighlighterBase.cs
@@ -80,7 +80,7 @@ namespace Community.VisualStudio.Toolkit
             ITextStructureNavigator? textStructureNavigator, SameWordHighlighterBase tagger)
         {
             _fileName = sourceBuffer.GetFileName();
-            System.Diagnostics.Debug.WriteLine("Create new tagger for "+_fileName);
+            //System.Diagnostics.Debug.WriteLine("Create new tagger for "+_fileName);
             _buffer = sourceBuffer;
             _textSearchService = textSearchService;
             _textStructureNavigator = textStructureNavigator;
@@ -97,7 +97,7 @@ namespace Community.VisualStudio.Toolkit
             textView.LayoutChanged += ViewLayoutChanged;
             textView.Closed += TextView_Closed;
             Counter += 1;
-            System.Diagnostics.Debug.WriteLine($"RegisterEvents {_fileName}: #{Counter} ");
+            //System.Diagnostics.Debug.WriteLine($"RegisterEvents {_fileName}: #{Counter} ");
         }
         internal void UnRegisterEvents(ITextView textView)
         {
@@ -105,7 +105,7 @@ namespace Community.VisualStudio.Toolkit
             textView.LayoutChanged -= ViewLayoutChanged;
             textView.Closed -= TextView_Closed;
             Counter -= 1;
-            System.Diagnostics.Debug.WriteLine($"UnRegisterEvents {_fileName}: #{Counter} ");
+            //System.Diagnostics.Debug.WriteLine($"UnRegisterEvents {_fileName}: #{Counter} ");
         }
         private void ViewLayoutChanged(object sender, TextViewLayoutChangedEventArgs e)
         {


### PR DESCRIPTION
Each TextView will register its events itself with the tagger from the textbuffer and when the textview is closed then the events are unregistered again.
The previous implementation was allocating way too many samewordhighlighters.
Also changed the color for the same word highlighters in the example code.