### PR TITLE
Change RegisterToolWindows to be ToolkitPackage extension method.

### DIFF
--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/AsyncPackageExtensions.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/AsyncPackageExtensions.cs
@@ -47,34 +47,5 @@ namespace Community.VisualStudio.Toolkit
             }
             return commands;
         }
-
-        /// <summary>
-        /// Automatically calls the <see cref="BaseToolWindow{T}.Initialize(ToolkitPackage)"/> method for every BaseToolWindow<> in the package or provided assemblies.
-        /// </summary>
-        /// <param name="package"></param>
-        /// <param name="assemblies"></param>
-        /// <returns></returns>
-        public static void RegisterToolWindows(this AsyncPackage package, params Assembly[] assemblies)
-        {
-            List<Assembly> assembliesList = assemblies.ToList();
-            Assembly packageAssembly = package.GetType().Assembly;
-            if (!assembliesList.Contains(packageAssembly))
-                assembliesList.Add(packageAssembly);
-
-            Type baseToolWindowType = typeof(BaseToolWindow<>);
-            IEnumerable<Type> toolWindowTypes = assembliesList.SelectMany(x => x.GetTypes())
-                .Where(x =>
-                    !x.IsAbstract
-                    && x.IsAssignableToGenericType(baseToolWindowType));
-
-            foreach (Type? toolWindowtype in toolWindowTypes)
-            {
-                MethodInfo initializeMethod = toolWindowtype.GetMethod(
-                    "Initialize",
-                    BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
-
-                initializeMethod.Invoke(null, new object[] { package });
-            }
-        }
     }
 }

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/ToolkitPackageExtensions.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/ExtensionMethods/ToolkitPackageExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.VisualStudio.Shell;
+
+namespace Community.VisualStudio.Toolkit
+{
+    /// <summary>
+    /// Extensions for an <see cref="ToolkitPackage"/>
+    /// </summary>
+    public static class ToolkitPackageExtensions
+    {
+        /// <summary>
+        /// Automatically calls the <see cref="BaseToolWindow{T}.Initialize(ToolkitPackage)"/> 
+        /// method for every <see cref="BaseToolWindow{T}"/> in the package or provided assemblies.
+        /// </summary>
+        /// <param name="package">The package that contains the tool windows to register.</param>
+        /// <param name="assemblies">The additional assemblies to look for tool windows in.</param>
+        public static void RegisterToolWindows(this ToolkitPackage package, params Assembly[] assemblies)
+        {
+            List<Assembly> assembliesList = assemblies.ToList();
+            Assembly packageAssembly = package.GetType().Assembly;
+            if (!assembliesList.Contains(packageAssembly))
+                assembliesList.Add(packageAssembly);
+
+            Type baseToolWindowType = typeof(BaseToolWindow<>);
+            IEnumerable<Type> toolWindowTypes = assembliesList.SelectMany(x => x.GetTypes())
+                .Where(x =>
+                    !x.IsAbstract
+                    && x.IsAssignableToGenericType(baseToolWindowType));
+
+            foreach (Type? toolWindowtype in toolWindowTypes)
+            {
+                MethodInfo initializeMethod = toolWindowtype.GetMethod(
+                    "Initialize",
+                    BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+
+                initializeMethod.Invoke(null, new object[] { package });
+            }
+        }
+    }
+}

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/VSSDK.Helpers.Shared.projitems
@@ -43,6 +43,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\IVsSolutionExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\IVsTextViewExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\TaskExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\ToolkitPackageExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\TypeExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods\WindowExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ContentTypes.cs" />


### PR DESCRIPTION
Fixes #463.

`BaseToolWindow.Initialize` requires a `ToolkitPackage`, so the extension method should be on `ToolkitPackage`, not `AsyncPackage`.