### PR TITLE
Added Write without new line to OutputWindowPane

### DIFF
--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Helpers/OutputWindowPane.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Helpers/OutputWindowPane.cs
@@ -237,6 +237,18 @@ namespace Community.VisualStudio.Toolkit
         }
 
         /// <summary>
+        /// Writes the given text to the Output window pane.
+        /// </summary>
+        /// <param name="value">The text value to write.</param>
+        public void Write(string value)
+        {
+            ThreadHelper.JoinableTaskFactory.Run(async () =>
+            {
+                await WriteAsync(value);
+            });
+        }
+
+        /// <summary>
         /// Writes a new line to the Output window pane.
         /// </summary>
         public Task WriteLineAsync()
@@ -250,6 +262,15 @@ namespace Community.VisualStudio.Toolkit
         /// <param name="value">The text value to write. May be an empty string, in which case a newline is written.</param>
         public async Task WriteLineAsync(string value)
         {
+            await WriteAsync(value + Environment.NewLine);
+        }
+
+        /// <summary>
+        /// Writes the given text to the Output window pane.
+        /// </summary>
+        /// <param name="value">The text value to write. May be an empty string, in which case a newline is written.</param>
+        public async Task WriteAsync(string value)
+        {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             await EnsurePaneAsync();
@@ -261,11 +282,11 @@ namespace Community.VisualStudio.Toolkit
 
             if (_pane is IVsOutputWindowPaneNoPump nopump)
             {
-                nopump.OutputStringNoPump(value + Environment.NewLine);
+                nopump.OutputStringNoPump(value);
             }
             else
             {
-                ErrorHandler.ThrowOnFailure(_pane.OutputStringThreadSafe(value + Environment.NewLine));
+                ErrorHandler.ThrowOnFailure(_pane.OutputStringThreadSafe(value));
             }
         }
 

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Helpers/OutputWindowPane.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Helpers/OutputWindowPane.cs
@@ -268,7 +268,7 @@ namespace Community.VisualStudio.Toolkit
         /// <summary>
         /// Writes the given text to the Output window pane.
         /// </summary>
-        /// <param name="value">The text value to write. May be an empty string, in which case a newline is written.</param>
+        /// <param name="value">The text value to write.</param>
         public async Task WriteAsync(string value)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();


### PR DESCRIPTION
As I need for my current project to write output into a single line, this would be a little enhancement. 

Added methods

- `void Write(string value);`
- `async Task WriteAsync(string value);`

Moved logic from `WriteLineAsync` to `WriteAsync`