### PR TITLE
Calculated the correct font size for use in WPF.

### DIFF
--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/FontsAndColors/BaseFontAndColorCategory.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/FontsAndColors/BaseFontAndColorCategory.cs
@@ -246,7 +246,7 @@ namespace Community.VisualStudio.Toolkit
             // only want to handle the changes for this category.
             if (rguidCategory.Equals(_categoryGuid))
             {
-                EmitChange((x) => x.SetFont(ref pInfo[0]));
+                EmitChange((x) => x.SetFont(ref pLOGFONT[0], ref pInfo[0]));
             }
             return VSConstants.S_OK;
         }

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/FontsAndColors/ConfiguredFontAndColorSet.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/FontsAndColors/ConfiguredFontAndColorSet.cs
@@ -14,13 +14,14 @@ namespace Community.VisualStudio.Toolkit
 
         internal ConfiguredFontAndColorSet(
             T category,
-            ref FontInfo font,
+            ref LOGFONTW logfont,
+            ref FontInfo fontInfo,
             Dictionary<ColorDefinition, ConfiguredColor> colors,
             Action<IFontAndColorChangeListener> onDispose
         )
         {
             Category = category;
-            Font = new ConfiguredFont(ref font);
+            Font = new ConfiguredFont(ref logfont, ref fontInfo);
             _colors = colors;
             _onDispose = onDispose;
         }
@@ -64,9 +65,9 @@ namespace Community.VisualStudio.Toolkit
         /// </summary>
         public event EventHandler<ConfiguredColorChangedEventArgs>? ColorChanged;
 
-        void IFontAndColorChangeListener.SetFont(ref FontInfo info)
+        void IFontAndColorChangeListener.SetFont(ref LOGFONTW logfont, ref FontInfo info)
         {
-            if (Font.Update(ref info))
+            if (Font.Update(ref logfont, ref info))
             {
                 FontChanged?.Invoke(this, EventArgs.Empty);
             }

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/FontsAndColors/FontsAndColors.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/FontsAndColors/FontsAndColors.cs
@@ -37,10 +37,12 @@ namespace Community.VisualStudio.Toolkit
                 T category = BaseFontAndColorCategory<T>.Instance;
 
                 FontInfo[] fontInfo = new FontInfo[1];
-                ErrorHandler.ThrowOnFailure(storage.GetFont(null, fontInfo));
+                LOGFONTW[] logfont = new LOGFONTW[1];
+                ErrorHandler.ThrowOnFailure(storage.GetFont(logfont, fontInfo));
 
                 ConfiguredFontAndColorSet<T> set = new(
                     category,
+                    ref logfont[0],
                     ref fontInfo[0],
                     await GetColorsAsync(category, categoryGuid, storage),
                     category.UnregisterChangeListener

--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/FontsAndColors/IFontAndColorChangeListener.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/FontsAndColors/IFontAndColorChangeListener.cs
@@ -4,7 +4,7 @@ namespace Community.VisualStudio.Toolkit
 {
     internal interface IFontAndColorChangeListener
     {
-        void SetFont(ref FontInfo info);
+        void SetFont(ref LOGFONTW logfont, ref FontInfo info);
 
         void SetColor(ColorDefinition definition, uint background, uint foreground, FontStyle fontStyle);
     }


### PR DESCRIPTION
The font size specified in the `FontInfo` object is in points. WPF does not use points for font sizes, so the font size was always smaller than it should have been.

Fixes #523.