### PR TITLE
Add overload for InterceptAsync with a command name, because some com…

### DIFF
--- a/src/toolkit/Community.VisualStudio.Toolkit.Shared/Commands/Commands.cs
+++ b/src/toolkit/Community.VisualStudio.Toolkit.Shared/Commands/Commands.cs
@@ -125,6 +125,19 @@ namespace Community.VisualStudio.Toolkit
 
             return new Disposable(() => priority.UnregisterPriorityCommandTarget(cookie));
         }
+        /// <summary>
+        /// Intercept any command before it is being handled by other command handlers.
+        /// </summary>
+        /// <returns>Returns an <see cref="IDisposable"/> that will remove the command interceptor when disposed.</returns>
+        public async Task<IDisposable> InterceptAsync(string name, Func<CommandProgression> func)
+        {
+            CommandID? cmd = await FindCommandAsync(name);
+            if (cmd == null)
+            {
+                throw new ArgumentException($"Command '{name}' not found.");
+            }
+            return await InterceptAsync(cmd, func);
+        }
     }
 
     internal class CommandInterceptor : IOleCommandTarget


### PR DESCRIPTION
…mands (such as Edit.ToggleLineComment) have no constants in the VS SDK files.